### PR TITLE
fix: the owner cannot be zero address in permit

### DIFF
--- a/contracts/ListaToken.sol
+++ b/contracts/ListaToken.sol
@@ -79,7 +79,7 @@ contract ListaToken is ERC20, IERC2612 {
             )
         );
         address recoveredAddress = ecrecover(digest, v, r, s);
-        require(recoveredAddress == owner, "ERC20Permit: invalid signature");
+        require(recoveredAddress == owner && recoveredAddress != address(0), "ERC20Permit: invalid signature");
         _approve(owner, spender, amount);
     }
 


### PR DESCRIPTION
If there is any balance on address(0), the balance can be claimed by any user.
This pr is used for fix this issue