### PR TITLE
fix: track epoch reward and unsettled reward

### DIFF
--- a/contracts/dao/SlisBnbDistributor.sol
+++ b/contracts/dao/SlisBnbDistributor.sol
@@ -87,6 +87,7 @@ contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
 
         // Rewards of current week will be exclued from the current epoch because they're not included in the merkle root
         epoch.reward = totalAllocated + unsettledReward - currentWeekReward;
+        require(epoch.reward > 0, "No reward for the epoch");
 
         // Rewards of current week will be included in the next epoch
         unsettledReward = currentWeekReward;
@@ -131,7 +132,7 @@ contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
         require(!claimed[week][account], "Airdrop already claimed");
 
         bytes32 leaf = keccak256(abi.encode(block.chainid, week, account, weight));
-        Epoch storage epoch = epochs[week];
+        Epoch memory epoch = epochs[week];
         MerkleVerifier._verifyProof(leaf, epoch.merkleRoot, proof);
 
         claimed[week][account] = true;

--- a/contracts/dao/SlisBnbDistributor.sol
+++ b/contracts/dao/SlisBnbDistributor.sol
@@ -8,6 +8,11 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IVault.sol";
 import "../MerkleVerifier.sol";
 
+/*
+    * @title SlisBnbDistributor
+    * @author Lista
+    * @dev Distribute rewards to users based on their slisBnb balance
+*/
 contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
     // LISTA vault; lista token will be transferred from this vault to users directly upon claim success
     IVault public vault;
@@ -15,8 +20,11 @@ contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
     // the id of slisBnb distributor
     uint16 private distributorId;
 
-    // week => bi-weekly merkle root
-    mapping(uint16 => bytes32) public merkleRoots;
+    // week => (merkleRoot, reward)
+    // week is the week of setting merkle root
+    // merkleRoot is the root of the merkle tree for the reward epoch
+    // epochReward is the total reward for the epoch
+    mapping(uint16 => Epoch) public epochs;
 
     // week => account => claimed
     mapping(uint16 => mapping(address => bool)) public claimed;
@@ -24,10 +32,21 @@ contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
     // claim expires after week + expireDelay
     uint256 public expireDelay;
 
+    // unsettledReward is not yet finalized and will be included in the next epoch
+    // since merkleRoot/epochReward can be updated/revoked within the same week of setting (one week dispute period),
+    // we need to keep track of the unsettled reward
+    uint256 public unsettledReward;
+
     // vault role
     bytes32 public constant VAULT = keccak256("VAULT");
 
-    event SetMerkleRoot(uint16 week, bytes32 merkleRoot);
+    struct Epoch {
+        // merkle root of an epoch
+        bytes32 merkleRoot;
+        // total reward of an epoch
+        uint256 reward;
+    }
+    event UpdateEpoch(uint16 week, bytes32 merkleRoot, uint256 reward, uint256 unsettledReward);
     event Claimed(address account, uint256 amount, uint16 week);
     event ExpireDelaySet(uint256 expireDelay);
 
@@ -52,25 +71,50 @@ contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
     }
 
     /**
-     * @dev Set merkle root for rewards epoch. Merkle root can only be updated before the epoch starts.
-     * @param _merkleRoot Merkle root of the rewards period
+     * @dev Set merkle root for rewards epoch.
+     * @param _merkleRoot Merkle root of the reward epoch
      */
     function setMerkleRoot(bytes32 _merkleRoot) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_merkleRoot != bytes32(0), "Invalid merkle root");
-        uint16 _week = vault.getWeek(block.timestamp);
+        uint16 _currentWeek = vault.getWeek(block.timestamp);
 
-        if (merkleRoots[_week] == bytes32(0)) {
-            vault.allocateNewEmissions(distributorId);
-        }
+        Epoch storage epoch = epochs[_currentWeek];
 
-        merkleRoots[_week] = _merkleRoot;
+        // Sync reward from the vault; fetch all unallocated rewards up to the current week, current week inclusive
+        uint256 totalAllocated = epoch.reward + vault.allocateNewEmissions(distributorId);
 
-        emit SetMerkleRoot(_week, _merkleRoot);
+        uint256 currentWeekReward = vault.getDistributorWeeklyEmissions(distributorId, _currentWeek);
+
+        // Rewards of current week will be exclued from the current epoch because they're not included in the merkle root
+        epoch.reward = totalAllocated + unsettledReward - currentWeekReward;
+
+        // Rewards of current week will be included in the next epoch
+        unsettledReward = currentWeekReward;
+
+        epoch.merkleRoot = _merkleRoot;
+
+        emit UpdateEpoch(_currentWeek, _merkleRoot, epoch.reward, unsettledReward);
     }
 
     /**
-     * @dev Claim Lista rewards. Can be called by anyone as long as proof is valid. Rewards are available after the rewards period ends.
-     * @param week Week of the rewards period
+     * @dev Revoke the reward of the current epoch;
+     *      the revoked amount will be added to unsettled reward which will be included in the next epoch
+     */
+    function revokeReward() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint16 _currentWeek = vault.getWeek(block.timestamp);
+        Epoch storage epoch = epochs[_currentWeek];
+        require(epoch.reward != 0, "No reward to revoke");
+
+        unsettledReward += epoch.reward;
+        epoch.reward = 0;
+        epoch.merkleRoot = bytes32(0);
+
+        emit UpdateEpoch(_currentWeek, epoch.merkleRoot, epoch.reward, unsettledReward);
+    }
+
+    /**
+     * @dev Claim Lista rewards. Can be called by anyone as long as proof is valid. Rewards are available after the one week dispute period ends.
+     * @param week Week of the rewards epoch
      * @param account Address of the recipient
      * @param weight Weight of the user's slisBnb balance against the total slisBnb balance
      * @param proof Merkle proof of the claim
@@ -87,11 +131,12 @@ contract SlisBnbDistributor is Initializable, AccessControlUpgradeable {
         require(!claimed[week][account], "Airdrop already claimed");
 
         bytes32 leaf = keccak256(abi.encode(block.chainid, week, account, weight));
-        MerkleVerifier._verifyProof(leaf, merkleRoots[week], proof);
+        Epoch storage epoch = epochs[week];
+        MerkleVerifier._verifyProof(leaf, epoch.merkleRoot, proof);
 
         claimed[week][account] = true;
 
-        uint256 amount = weight * vault.getDistributorWeeklyEmissions(distributorId, week) / 1e18;
+        uint256 amount = weight * epoch.reward / 1e18;
         vault.transferAllocatedTokens(distributorId, account, amount);
 
         emit Claimed(account, amount, week);


### PR DESCRIPTION
Since `vault.getDistributorWeeklyEmissions` only returns the rewards of current week, not the rewards of current epoch; we need to update our logic to keep track of epoch rewards and unsettled rewards