### PR TITLE
VeLista Auto Compound

### DIFF
--- a/contracts/VeListaAutoCompounder.sol
+++ b/contracts/VeListaAutoCompounder.sol
@@ -77,6 +77,7 @@ contract VeListaAutoCompounder is Initializable, AccessControlUpgradeable {
     );
     event FeeWithdrawn(address indexed _receiver, uint256 _fee);
     event FeeReceiverUpdated(address indexed _newReceiver);
+    event DefaultStatusToggled(bool _defaultStatus);
 
     function initialize(
         address _lista,
@@ -208,6 +209,7 @@ contract VeListaAutoCompounder is Initializable, AccessControlUpgradeable {
      */
     function toggleDefaultStatus() external onlyRole(DEFAULT_ADMIN_ROLE) {
         enableByDefault = !enableByDefault;
+        emit DefaultStatusToggled(enableByDefault);
     }
 
     /**

--- a/contracts/VeListaAutoCompounder.sol
+++ b/contracts/VeListaAutoCompounder.sol
@@ -163,6 +163,9 @@ contract VeListaAutoCompounder is Initializable, AccessControlUpgradeable {
         );
         uint256 amtToCompound = getAmountToCompound(claimedAmount);
 
+        // Approve veLista to spend the amount to compound
+        lista.approve(address(veLista), amtToCompound);
+
         IVeLista(veLista).increaseAmountFor(account, amtToCompound);
 
         totalFee += claimedAmount - amtToCompound;

--- a/contracts/VeListaAutoCompounder.sol
+++ b/contracts/VeListaAutoCompounder.sol
@@ -113,10 +113,6 @@ contract VeListaAutoCompounder is Initializable, AccessControlUpgradeable {
 
         feeRate = 300; // 3%
         maxFeeRate = 1000; // 10%
-        require(
-            feeRate <= maxFeeRate && maxFeeRate <= 10000,
-            "Invalid fee rate"
-        );
 
         autoCompoundThreshold = 5 * 1e18; // $5
         maxFee = 1000000 * 1e18; // $1M

--- a/scripts/upgrade_compounder.ts
+++ b/scripts/upgrade_compounder.ts
@@ -1,0 +1,23 @@
+import { upgradeProxy, validateUpgrade } from "./tasks";
+import hre from "hardhat";
+
+const proxyAddress = "0x07eEb2981Bc28783B4977998117f70B53E172024";
+
+async function main() {
+  //validateUpgrade(hre, "contracts/old/VeListaAutoCompounder.sol:VeListaAutoCompounder", "contracts/VeListaAutoCompounder.sol:VeListaAutoCompounder");
+  //const oldCompounder = await hre.ethers.getContractFactory("contracts/old/VeListaAutoCompounder.sol:VeListaAutoCompounder");
+  //await hre.upgrades.forceImport(proxyAddress, oldCompounder);
+
+  await upgradeProxy(
+    hre,
+    "contracts/VeListaAutoCompounder.sol:VeListaAutoCompounder",
+    proxyAddress
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Added `VeListaAutoCompounder` contract to support veLista reward auto-compounding feature, which claim rewards from `veListaDistributor` and then lock them into `veLista`.

Changes include:
* Added `VeListaAutoCompounder` contract
* Added compounder role to `veListaDistributor`
* Added `claimForCompound` method to `veListaDistributor`
* Added `increaseAmountFor` method to `veLista`

Unit tests passed:
<img width="792" alt="image" src="https://github.com/user-attachments/assets/cbc189f7-bb6c-4fcf-828b-fac7f1738ccf">