### PR TITLE
fix: add disableInitializers to VeListaAutoCompounder

### DIFF
--- a/contracts/VeListaAutoCompounder.sol
+++ b/contracts/VeListaAutoCompounder.sol
@@ -79,6 +79,11 @@ contract VeListaAutoCompounder is Initializable, AccessControlUpgradeable {
     event FeeReceiverUpdated(address indexed _newReceiver);
     event DefaultStatusToggled(bool _defaultStatus);
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function initialize(
         address _lista,
         address _velista,

--- a/scripts/deploy_compounder_impl.ts
+++ b/scripts/deploy_compounder_impl.ts
@@ -1,0 +1,13 @@
+import { deployDirect } from "./tasks";
+import hre from "hardhat";
+
+async function main() {
+  await deployDirect(hre, "contracts/VeListaAutoCompounder.sol:VeListaAutoCompounder");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Added `_disableInitializers` to avoid impl contract uninitialized per [OpenZepplin's suggestion](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/proxy/utils/Initializable.sol#L41)

<img width="728" alt="image" src="https://github.com/user-attachments/assets/0a7e246c-d462-4bb4-8627-170f0580c6a8">
