### PR TITLE
feature: add snapshot for borrowing lisUSD per collateral

### DIFF
--- a/contracts/dao/BorrowListaDistributor.sol
+++ b/contracts/dao/BorrowListaDistributor.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "./CommonListaDistributor.sol";
+
+/**
+ * @title BorrowListaDistributor
+ * @dev This contract stores user's LISTA reward for borrowing LisUSD of a single collateral in CDP
+ */
+contract BorrowListaDistributor is CommonListaDistributor {
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /**
+   * @dev Initialize contract
+   * @param _name collateral token name
+   * @param _symbol collateral token symbol
+   * @param _admin admin address
+   * @param _manager manager address
+   * @param _vault lista vault address
+   * @param _lpToken collateral token address
+   */
+  function initialize(
+    string memory _name,
+    string memory _symbol,
+    address _admin,
+    address _manager,
+    address _vault,
+    address _lpToken
+  ) external initializer {
+    require(_admin != address(0), "admin cannot be a zero address");
+    require(_manager != address(0), "manager cannot be a zero address");
+    require(_lpToken != address(0), "lp token cannot be a zero address");
+    require(_vault != address(0), "vault is the zero address");
+
+    __AccessControl_init();
+    __Pausable_init();
+
+    _setupRole(DEFAULT_ADMIN_ROLE, _admin);
+    _setupRole(MANAGER, _manager);
+    _setupRole(VAULT, _vault);
+    name = _name;
+    symbol = _symbol;
+    vault = IVault(_vault);
+    lpToken = _lpToken;
+  }
+
+  /**
+   * @notice take snapshot of user's activity
+   * @dev only the Interaction contract(Manager Role) can call this function,
+   *      it will do the checking in the Interaction Contract,
+   *      so there is no need to add checking here
+   * @param _token collateral token address
+   * @param _user user address
+   * @param _debt user's latest debt by borrowing LisUSD from the collateral
+   */
+  function takeSnapshot(address _token, address _user, uint256 _debt) external onlyRole(MANAGER) {
+    require(_token == lpToken, "collateral token is not matched");
+
+    uint256 lastDebt = balanceOf[_user];
+    if (_debt == lastDebt) {
+      return; // do nothing if debt is not changed
+    }
+
+    if (_debt > lastDebt) {
+      _deposit(_user, _debt - lastDebt);
+    } else {
+      _withdraw(_user, lastDebt - _debt);
+    }
+  }
+}

--- a/contracts/dao/CollateralBorrowSnapshotRouter.sol
+++ b/contracts/dao/CollateralBorrowSnapshotRouter.sol
@@ -90,19 +90,6 @@ contract CollateralBorrowSnapshotRouter is Initializable, AccessControlUpgradeab
     }
 
     /**
-     * @dev take snapshot of user's activity, to make router compatible with existing borrowLisUSDListaDistributor
-     * only the Interaction contract(Manager Role) can call this function
-     * @param _collateralToken token address
-     * @param _user user address
-     * @param _art user's borrow amount
-     */
-    function takeSnapshot(
-        address _collateralToken, address _user, uint256 _art
-    ) onlyRole(MANAGER) external {
-        borrowDistributors[_collateralToken].takeSnapshot(_collateralToken, _user, _art);
-    }
-
-    /**
      * @dev set new collateral distributor
      */
     function setCollateralDistributor(address _collateralToken, address _collateralDistributor) onlyRole(DEFAULT_ADMIN_ROLE) external {

--- a/contracts/dao/interfaces/ICollateralDistributor.sol
+++ b/contracts/dao/interfaces/ICollateralDistributor.sol
@@ -4,3 +4,7 @@ pragma solidity ^0.8.10;
 interface ICollateralDistributor {
     function takeSnapshot(address _token, address _user, uint256 _ink) external;
 }
+
+interface IBorrowDistributor {
+    function takeSnapshot(address _token, address _user, uint256 _debt) external;
+}

--- a/contracts/dao/interfaces/ICollateralDistributor.sol
+++ b/contracts/dao/interfaces/ICollateralDistributor.sol
@@ -7,4 +7,5 @@ interface ICollateralDistributor {
 
 interface IBorrowDistributor {
     function takeSnapshot(address _token, address _user, uint256 _debt) external;
+    function lpToken() external view returns (address);
 }

--- a/contracts/old/CollateralBorrowSnapshotRouter.sol
+++ b/contracts/old/CollateralBorrowSnapshotRouter.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../dao/interfaces/IBorrowLisUSDListaDistributor.sol";
+import "../dao/interfaces/ICollateralDistributor.sol";
+
+/**
+ */
+contract CollateralBorrowSnapshotRouter is Initializable, AccessControlUpgradeable {
+
+    using SafeERC20 for IERC20;
+
+    event CollateralDistributorChanged(address indexed distributor, address indexed token, bool isAdd);
+    event BorrowDistributorChanged(address indexed newAddress);
+
+    bytes32 public constant MANAGER = keccak256("MANAGER");
+
+    mapping(address => ICollateralDistributor) public collateralDistributors;
+
+    IBorrowLisUSDListaDistributor public borrowLisUSDListaDistributor;
+
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+    * @dev Initialize contract
+    * @param _admin admin address
+    * @param _manager manager address
+    * @param _borrowLisUSDListaDistributor address of BorrowLisUSDListaDistributor
+    * @param _collateralTokens address of collateral tokens
+    * @param _collateralDistributors address of collateral distributors
+    */
+    function initialize(
+        address _admin,
+        address _manager,
+        address _borrowLisUSDListaDistributor,
+        address[] memory _collateralTokens,
+        address[] memory _collateralDistributors
+    ) external initializer {
+        require(_admin != address(0), "admin cannot be a zero address");
+        require(_manager != address(0), "manager cannot be a zero address");
+        require(_borrowLisUSDListaDistributor != address(0), "borrowLisUSDListaDistributor cannot be a zero address");
+        require(_collateralTokens.length == _collateralDistributors.length, "collateralTokens and collateralDistributors length mismatch");
+
+        __AccessControl_init();
+        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
+        _setupRole(MANAGER, _manager);
+
+        borrowLisUSDListaDistributor = IBorrowLisUSDListaDistributor(_borrowLisUSDListaDistributor);
+
+        for (uint256 i = 0; i < _collateralTokens.length; i++) {
+            require(_collateralDistributors[i] != address(0), "collateralDistributor cannot be a zero address");
+            collateralDistributors[_collateralTokens[i]] = ICollateralDistributor(_collateralDistributors[i]);
+        }
+    }
+
+    /**
+     * @dev take snapshot of user's activity
+     * only the Interaction contract(Manager Role) can call this function
+     * @param _collateralToken token address
+     * @param _user user address
+     * @param _ink user's collateral amount
+     * @param _art user's borrow amount
+     * @param _inkUpdated whether user's collateral amount is updated
+     * @param _artUpdated whether user's borrow amount is updated
+     */
+    function takeSnapshot(
+        address _collateralToken, address _user,
+        uint256 _ink, uint256 _art,
+        bool _inkUpdated, bool _artUpdated
+    ) onlyRole(MANAGER) external {
+        if (_inkUpdated && address(collateralDistributors[_collateralToken]) != address(0)) {
+            collateralDistributors[_collateralToken].takeSnapshot(_collateralToken, _user, _ink);
+        }
+
+        if (_artUpdated) {
+            borrowLisUSDListaDistributor.takeSnapshot(_collateralToken, _user, _art);
+        }
+    }
+
+    /**
+     * @dev take snapshot of user's activity, to make router compatible with existing borrowLisUSDListaDistributor
+     * only the Interaction contract(Manager Role) can call this function
+     * @param _collateralToken token address
+     * @param _user user address
+     * @param _art user's borrow amount
+     */
+    function takeSnapshot(
+        address _collateralToken, address _user, uint256 _art
+    ) onlyRole(MANAGER) external {
+        borrowLisUSDListaDistributor.takeSnapshot(_collateralToken, _user, _art);
+    }
+
+    /**
+     * @dev set new collateral distributor
+     */
+    function setCollateralDistributor(address _collateralToken, address _collateralDistributor) onlyRole(DEFAULT_ADMIN_ROLE) external {
+        require(_collateralDistributor != address(0), "collateralDistributor cannot be a zero address");
+        require(_collateralDistributor != address(collateralDistributors[_collateralToken]), "collateralDistributor already set");
+
+        collateralDistributors[_collateralToken] = ICollateralDistributor(_collateralDistributor);
+        emit CollateralDistributorChanged(_collateralDistributor, _collateralToken, true);
+    }
+
+    /**
+     * @dev remove collateral distributor
+     */
+    function unsetCollateralDistributor(address _collateralToken) onlyRole(DEFAULT_ADMIN_ROLE) external {
+        address existingDistributor = address(collateralDistributors[_collateralToken]);
+        require(existingDistributor != address(0), "collateralDistributor not set");
+
+        delete collateralDistributors[_collateralToken];
+        emit CollateralDistributorChanged(existingDistributor, _collateralToken, false);
+    }
+}

--- a/scripts/dao/deploy_borrowListaDistributors.ts
+++ b/scripts/dao/deploy_borrowListaDistributors.ts
@@ -1,0 +1,85 @@
+import { deployProxy } from "../tasks";
+import hre from "hardhat";
+
+const collateralConfigs: any[] = [{
+  symbol: 'ceABNBc BorrowListaDAODistributor',
+  lpToken: '0x92D8c63E893685Cced567b23916a8726b0CEF3FE',
+}, {
+  symbol: 'slisBNB BorrowListaDAODistributor',
+  lpToken: '0xCc752dC4ae72386986d011c2B485be0DAd98C744',
+}, {
+  symbol: 'cewBETH BorrowListaDAODistributor',
+  lpToken: '0xf1Abbc41721D0970BEa2e84C5bC159F8D3Cac760',
+}, {
+  symbol: 'wBETH BorrowListaDAODistributor',
+  lpToken: '0x34f8f72e3f14Ede08bbdA1A19a90B35a80f3E789',
+}, {
+  symbol: 'wstETH BorrowListaDAODistributor',
+  lpToken: '0x41e3750FafC565f89c11DF06fEE257b93bB19A31',
+}, {
+  symbol: 'BTCB BorrowListaDAODistributor',
+  lpToken: '0x4BB2f2AA54c6663BFFD37b54eCd88eD81bC8B3ec',
+}, {
+  symbol: 'USDT BorrowListaDAODistributor',
+  lpToken: '0x49b1401B4406Fe0B32481613bF1bC9Fe4B9378aC',
+}, {
+  symbol: 'FDUSD BorrowListaDAODistributor',
+  lpToken: '0xadbccCa89eC498F8B9B7F6A4B05206b113676861',
+}, {
+  symbol: 'STONE BorrowListaDAODistributor',
+  lpToken: '0xb982479692b9f9D5d6582a36f49255205b18aE9e',
+}, {
+  symbol: 'solvBTC BorrowListaDAODistributor',
+  lpToken: '0xB1E63330f4718772CF939128d222389b30C70cF2',
+}, {
+  symbol: 'SolvBTC.BBN BorrowListaDAODistributor',
+  lpToken: '0x16D9A837e0D1AAC45937425caC26CcB729388C9A',
+}, {
+  symbol: 'sUSDX BorrowListaDAODistributor',
+  lpToken: '0xdb66d7e8edF8a16aD5e802704D2cA4EFca9e8a46',
+}, {
+  symbol: 'cePumpBTC BorrowListaDAODistributor',
+  lpToken: '0xF95144b8aeFeeD7cBea231D24Be53766223Ad5f0',
+}]
+
+async function main() {
+  const name = "ListaDao";
+  const signers = await hre.ethers.getSigners();
+  const deployer = signers[0].address;
+  let listaVault = '', manager;
+  if (hre.network.name === "bsc") {
+    listaVault = "0x307d13267f360f78005f476Fa913F8848F30292A";
+    manager = ""; // router address
+  } else if (hre.network.name === "bscTestnet") {
+    listaVault = "0x1D70D733401169055002FB4450942F15C2F088d4";
+    manager = "0x227eeaf69495E97c1E72A48785B8A041664b5a28"; // router address
+  }
+
+  for (const collateralConfig of collateralConfigs) {
+    console.log(`BorrowListaDistributor loop start, ${collateralConfig.symbol}`);
+
+    const address = await deployProxy(
+      hre,
+      "BorrowListaDistributor",
+      name,
+      collateralConfig.symbol,
+      deployer,
+      manager,
+      listaVault,
+      collateralConfig.lpToken
+    );
+    console.log(`BorrowListaDistributor loop done, ${collateralConfig.symbol} deployed to: ${address}`);
+
+    // const contract = await hre.ethers.getContractAt("ListaVault", listaVault);
+    // await contract.registerDistributor(address);
+  }
+
+  console.log(`BorrowListaDistributor all done`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/dao/deploy_router_impl.ts
+++ b/scripts/dao/deploy_router_impl.ts
@@ -1,0 +1,15 @@
+import { deployDirect } from "../tasks";
+import hre from "hardhat";
+
+async function main() {
+  let newImpl = 'contracts/dao/CollateralBorrowSnapshotRouter.sol:CollateralBorrowSnapshotRouter';
+
+  await deployDirect(hre, newImpl);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/dao/upgrade_router.ts
+++ b/scripts/dao/upgrade_router.ts
@@ -1,0 +1,26 @@
+import { upgradeProxy, validateUpgrade } from "../tasks";
+import hre from "hardhat";
+
+const proxyAddress = "0x227eeaf69495E97c1E72A48785B8A041664b5a28";
+
+async function main() {
+  let old = 'contracts/old/CollateralBorrowSnapshotRouter.sol:CollateralBorrowSnapshotRouter';
+  let newImpl = 'contracts/dao/CollateralBorrowSnapshotRouter.sol:CollateralBorrowSnapshotRouter';
+  validateUpgrade(hre, old, newImpl);
+  console.log("Upgrade validated");
+  const oldVeLista = await hre.ethers.getContractFactory(old);
+  await hre.upgrades.forceImport(proxyAddress, oldVeLista);
+
+  await upgradeProxy(
+    hre,
+    newImpl,
+    proxyAddress
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/dao/BorrowListaDistributor.t.sol
+++ b/test/dao/BorrowListaDistributor.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import "../../contracts/dao/BorrowListaDistributor.sol";
+
+contract BorrowListaDistributorTest is Test {
+
+    address admin = address(0x1A11AA);
+    address manager = address(0x2A11AA);
+    address user = address(0x3A11AA);
+    address proxyAdminOwner = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+    address listaVault = address(0x307d13267f360f78005f476Fa913F8848F30292A);
+
+    uint256 mainnet;
+
+    IERC20 slisBNB;
+
+    BorrowListaDistributor slisBnbBorrowlDistributor;
+
+    function setUp() public {
+        mainnet = vm.createSelectFork("https://bsc-dataseed.binance.org");
+        slisBNB = IERC20(0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B);
+
+        BorrowListaDistributor slisBnbBorrowlDistributorImpl = new BorrowListaDistributor();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(slisBnbBorrowlDistributorImpl),
+            proxyAdminOwner,
+            abi.encodeWithSignature(
+                "initialize(string,string,address,address,address,address)",
+                "slisBNBBorrowDistributor", "slisBNB", admin, manager, listaVault, address(slisBNB)
+            )
+        );
+
+        slisBnbBorrowlDistributor = BorrowListaDistributor(address(proxy));
+
+        assertEq("slisBNBBorrowDistributor", slisBnbBorrowlDistributor.name());
+    }
+
+    function test_takeSnapshot() public {
+        assertEq(0, slisBnbBorrowlDistributor.balanceOf(user));
+
+        vm.startPrank(manager);
+        slisBnbBorrowlDistributor.takeSnapshot(address(slisBNB), user, 123e18);
+        vm.stopPrank();
+
+        assertEq(123e18, slisBnbBorrowlDistributor.balanceOf(user));
+    }
+}

--- a/test/dao/CollateralBorrowSnapshotRouter.t.sol
+++ b/test/dao/CollateralBorrowSnapshotRouter.t.sol
@@ -191,17 +191,4 @@ contract CollateralBorrowSnapshotRouterTest is Test {
         assertEq(123e18, slisBNBCollateralDistributor.balanceOf(user));
         assertEq(456e18, slisBnbBorrowListaDistributor.balanceOf(user));
     }
-
-    function test_takeSnapshot_collateral_borrow_compatible() public {
-        assertEq(0, slisBnbBorrowListaDistributor.balanceOf(user));
-
-        vm.expectEmit(address(slisBnbBorrowListaDistributor));
-        emit CommonListaDistributor.LPTokenDeposited(address(slisBNB), user, 456e18);
-
-        vm.startPrank(manager);
-        collateralBorrowSnapshotRouter.takeSnapshot(address(slisBNB), user, 456e18);
-        vm.stopPrank();
-
-        assertEq(456e18, slisBnbBorrowListaDistributor.balanceOf(user));
-    }
 }


### PR DESCRIPTION
* Add `BorrowListaDistributor` to track users LISTA rewards for borrowing lisUSD for a single collateral
* Updated `CollateralBorrowSnapshotRouter` to support snapshots for borrowing activity for a single collateral