### PR TITLE
feature: use block.timestamp as start/end time for s3 airdrop

### DIFF
--- a/scripts/deploy-airdrop.ts
+++ b/scripts/deploy-airdrop.ts
@@ -3,42 +3,39 @@ import { ethers } from "hardhat";
 const TOKEN = "0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46";
 const ROOT = "0xe12f80c861a5ffa2756ee8fa6238c51fb5bd5114675d2cb580a08e64c0a642cf";
 const RECLAIM_DELAY = 0;
-const START_BLOCK = 39773281;
-const END_BLOCK = 40609575;
+const START_TIME = 1737446400; // Tue Jan 21 2025 08:00:00 GMT+0000
+const END_TIME = 1755763200; // Thu Aug 21 2025 08:00:00 GMT+0000
 
 async function main() {
-  //  const startBlock = (await ethers.provider.getBlockNumber()) + 5;
-  //  console.log("Start block:", startBlock);
-
   const MerkleVerifier = await ethers.getContractFactory("MerkleVerifier");
   const merkleVerifier = await MerkleVerifier.deploy();
-  await merkleVerifier.deployed();
-  console.log("MerkleVerifier deployed to:", merkleVerifier.address);
+  await merkleVerifier.waitForDeployment();
+  console.log("MerkleVerifier deployed to:", merkleVerifier.target);
 
   const ListaAirdrop = await ethers.getContractFactory("ListaAirdrop", {
     libraries: {
-      MerkleVerifier: merkleVerifier.address,
+      MerkleVerifier: merkleVerifier.target,
     },
   });
   const listaAirdrop = await ListaAirdrop.deploy(
     TOKEN, // token
     ROOT, // root
     RECLAIM_DELAY, // reclaimDelay
-    START_BLOCK, // startBlock
-    END_BLOCK // endBlock
+    START_TIME, // startTime
+    END_TIME // endTime
   );
-  await listaAirdrop.deployed();
+  await listaAirdrop.waitForDeployment();
 
-  console.log("ListaAirdrop deployed to:", listaAirdrop.address);
+  console.log("ListaAirdrop deployed to:", listaAirdrop.target);
 
   await run("verify:verify", {
-    address: listaAirdrop.address,
+    address: listaAirdrop.target,
     constructorArguments: [
       TOKEN, // token
       ROOT, // root
       RECLAIM_DELAY, // reclaimDelay
-      START_BLOCK, // startBlock
-      END_BLOCK, // endBlock
+      START_TIME, // startTime
+      END_TIME // endTime
     ],
   });
 }

--- a/scripts/deploy-airdrop.ts
+++ b/scripts/deploy-airdrop.ts
@@ -1,7 +1,8 @@
 import { ethers } from "hardhat";
+import hre from "hardhat";
 
-const TOKEN = "0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46";
-const ROOT = "0xe12f80c861a5ffa2756ee8fa6238c51fb5bd5114675d2cb580a08e64c0a642cf";
+let token = "";
+const ROOT = "0x93f599435d274a0e423df9717e4d19c1595513874cedcc6ab8cb8b6d7afae9d5";
 const RECLAIM_DELAY = 0;
 const START_TIME = 1737446400; // Tue Jan 21 2025 08:00:00 GMT+0000
 const END_TIME = 1755763200; // Thu Aug 21 2025 08:00:00 GMT+0000
@@ -12,13 +13,18 @@ async function main() {
   await merkleVerifier.waitForDeployment();
   console.log("MerkleVerifier deployed to:", merkleVerifier.target);
 
+  if (hre.network.name === "bsc") {
+    token = "0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46"; // LISTA
+  } else if (hre.network.name === "bscTestnet") {
+    token = "0x90b94D605E069569Adf33C0e73E26a83637c94B1";
+  }
   const ListaAirdrop = await ethers.getContractFactory("ListaAirdrop", {
     libraries: {
       MerkleVerifier: merkleVerifier.target,
     },
   });
   const listaAirdrop = await ListaAirdrop.deploy(
-    TOKEN, // token
+    token, // LISTA token
     ROOT, // root
     RECLAIM_DELAY, // reclaimDelay
     START_TIME, // startTime
@@ -31,7 +37,7 @@ async function main() {
   await run("verify:verify", {
     address: listaAirdrop.target,
     constructorArguments: [
-      TOKEN, // token
+      token, // token
       ROOT, // root
       RECLAIM_DELAY, // reclaimDelay
       START_TIME, // startTime

--- a/test/listaAirDrop.test.ts
+++ b/test/listaAirDrop.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { MerkleTree } from "merkletreejs";
-import { mine, time } from "@nomicfoundation/hardhat-network-helpers";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 function toWei(eth: string) {
   return ethers.parseEther(eth).toString();
@@ -72,7 +72,7 @@ describe("ListaAirdrop", function () {
     // const endTime = 1755763200; // Thu Aug 21 2025 08:00:00 GMT+0000
     const startTime = (await time.latest()) + 10;
     const endTime = startTime + 6 * 30 * 24 * 60 * 60; // 6 months
-    const reclaimDelay = endTime;
+    const reclaimDelay = 0;
     const ListaAirdrop = await ethers.getContractFactory("ListaAirdrop", {
       libraries: {
         MerkleVerifier: merkleVerifier.target,
@@ -113,15 +113,13 @@ describe("ListaAirdrop", function () {
     await time.increase(200);
 
     // shoule revert if incorrect proof provided
-    /*
-  await expect(
-      listaAirdrop.claim(
+    await expect(
+       listaAirdrop.claim(
         user1.address,
         toWei("1"),
         proof2.map((p) => "0x" + p.data.toString("hex"))
       )
-    ).to.be.revertedWith("InvalidProof()");
-    */
+    ).to.be.revertedWithCustomError(merkleVerifier, "InvalidProof");
 
     // user1 can claim
     await expect(
@@ -181,10 +179,6 @@ describe("ListaAirdrop", function () {
 
   it("owner should be able to reclaim", async function () {
     const balanceBefore = await listaToken.balanceOf(owner.address);
-    await expect(listaAirdrop.connect(owner).reclaim(toWei("1"))).to.be.revertedWith("Tokens cannot be reclaimed");
-
-    // advance to end time
-    await time.increase( (await time.latest()) + 7 * 30 * 24 * 60 * 60);
     await listaAirdrop.connect(owner).reclaim(toWei("1"));
 
     expect(await listaToken.balanceOf(owner.address)).to.equals(

--- a/test/listaAirDrop.test.ts
+++ b/test/listaAirDrop.test.ts
@@ -1,14 +1,14 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { MerkleTree } from "merkletreejs";
-import { mine } from "@nomicfoundation/hardhat-network-helpers";
+import { mine, time } from "@nomicfoundation/hardhat-network-helpers";
 
 function toWei(eth: string) {
-  return ethers.utils.parseEther(eth).toString();
+  return ethers.parseEther(eth).toString();
 }
 
 function leafHash(address: string, amount: string) {
-  return ethers.utils.solidityKeccak256(
+  return ethers.solidityPackedKeccak256(
     ["address", "uint256"],
     [address, amount]
   );
@@ -40,7 +40,7 @@ describe("ListaAirdrop", function () {
       leafHash(user4.address, toWei("101")), // user4 node
     ];
 
-    tree = new MerkleTree(leaves, ethers.utils.keccak256, {
+    tree = new MerkleTree(leaves, ethers.keccak256, {
       sortPairs: true,
     });
 
@@ -62,36 +62,38 @@ describe("ListaAirdrop", function () {
 
     // contract deploy treasury
     listaToken = await ethers.deployContract("ListaToken", [treasury.address]);
-    await listaToken.deployed();
+    await listaToken.waitForDeployment();
 
     const MerkleVerifier = await ethers.getContractFactory("MerkleVerifier");
     merkleVerifier = await MerkleVerifier.deploy();
-    await merkleVerifier.deployed();
+    await merkleVerifier.waitForDeployment();
 
-    const reclaimDelay = 0;
-    const startBlock = (await ethers.provider.getBlockNumber()) + 20;
-    const endBlock = startBlock + 200;
+    // const startTime = 1737446400; // Tue Jan 21 2025 08:00:00 GMT+0000
+    // const endTime = 1755763200; // Thu Aug 21 2025 08:00:00 GMT+0000
+    const startTime = (await time.latest()) + 10;
+    const endTime = startTime + 6 * 30 * 24 * 60 * 60; // 6 months
+    const reclaimDelay = endTime;
     const ListaAirdrop = await ethers.getContractFactory("ListaAirdrop", {
       libraries: {
-        MerkleVerifier: merkleVerifier.address,
+        MerkleVerifier: merkleVerifier.target,
       },
     });
-    const fakeRoot = ethers.utils.formatBytes32String("");
+    const fakeRoot = ethers.encodeBytes32String("");
     listaAirdrop = await ListaAirdrop.deploy(
-      listaToken.address,
+      listaToken.target,
       fakeRoot, // bytes32
       reclaimDelay,
-      startBlock,
-      endBlock
+      startTime,
+      endTime
     );
-    await listaAirdrop.deployed();
+    await listaAirdrop.waitForDeployment();
 
     await listaToken
       .connect(treasury)
-      .transfer(listaAirdrop.address, toWei("10"));
+      .transfer(listaAirdrop.target, toWei("10"));
 
-    await listaAirdrop.setStartBlock(startBlock + 1);
-    expect(await listaAirdrop.startBlock()).to.equals(startBlock + 1);
+    await listaAirdrop.setStartTime(startTime + 1);
+    expect(await listaAirdrop.startTime()).to.equals(startTime + 1);
   });
 
   it("should work", async function () {
@@ -107,17 +109,19 @@ describe("ListaAirdrop", function () {
       )
     ).to.be.revertedWith("Airdrop not started or has ended");
 
-    // advance to start block
-    await mine(20);
+    // advance to start time
+    await time.increase(200);
 
     // shoule revert if incorrect proof provided
-    await expect(
+    /*
+  await expect(
       listaAirdrop.claim(
         user1.address,
         toWei("1"),
         proof2.map((p) => "0x" + p.data.toString("hex"))
       )
     ).to.be.revertedWith("InvalidProof()");
+    */
 
     // user1 can claim
     await expect(
@@ -162,8 +166,8 @@ describe("ListaAirdrop", function () {
       )
     ).to.be.revertedWith("Airdrop already claimed");
 
-    // advance to end block
-    await mine(30000);
+    // advance to end time
+    await time.increase(200 + 6 * 30 * 24 * 60 * 60);
 
     // user4 can't claim
     await expect(
@@ -177,38 +181,43 @@ describe("ListaAirdrop", function () {
 
   it("owner should be able to reclaim", async function () {
     const balanceBefore = await listaToken.balanceOf(owner.address);
+    await expect(listaAirdrop.connect(owner).reclaim(toWei("1"))).to.be.revertedWith("Tokens cannot be reclaimed");
+
+    // advance to end time
+    await time.increase( (await time.latest()) + 7 * 30 * 24 * 60 * 60);
     await listaAirdrop.connect(owner).reclaim(toWei("1"));
+
     expect(await listaToken.balanceOf(owner.address)).to.equals(
-      balanceBefore.add(toWei("1"))
+      balanceBefore + toWei("1")
     );
   });
 
   it("owner should not be able to set merkle root once claim started", async function () {
-    const newRoot = ethers.utils.formatBytes32String("");
+    const newRoot = ethers.encodeBytes32String("");
     await expect(listaAirdrop.setMerkleRoot(newRoot)).to.be.revertedWith(
       "Cannot change merkle root after airdrop has started"
     );
   });
 
-  it("owner should be not able to set start block after ended", async function () {
-    const startBlock = await listaAirdrop.startBlock();
-    await expect(listaAirdrop.setStartBlock(startBlock)).to.be.revertedWith(
-      "Start block already set"
+  it("owner should be not able to set start time after ended", async function () {
+    const startTime = await listaAirdrop.startTime();
+    await expect(listaAirdrop.setStartTime(startTime)).to.be.revertedWith(
+      "Start time already set"
     );
-    const newStartBlock = (await ethers.provider.getBlockNumber()) + 1;
-    await expect(listaAirdrop.setStartBlock(newStartBlock)).to.be.revertedWith(
-      "Invalid start block"
+    const newStartTime = (await time.latest()) + 100;
+    await expect(listaAirdrop.setStartTime(newStartTime)).to.be.revertedWith(
+      "Invalid start time"
     );
   });
 
-  it("owner should be able to set end block", async function () {
-    const endBlock = await listaAirdrop.endBlock();
-    await expect(listaAirdrop.setEndBlock(endBlock)).to.be.revertedWith(
-      "End block already set"
+  it("owner should be able to set end time", async function () {
+    const endTime = await listaAirdrop.endTime();
+    await expect(listaAirdrop.setEndTime(endTime)).to.be.revertedWith(
+      "End time already set"
     );
-    const newEndBlock = (await ethers.provider.getBlockNumber()) + 200;
-    await listaAirdrop.setEndBlock(newEndBlock);
+    const newEndTime = endTime + "0";
+    await listaAirdrop.setEndTime(newEndTime);
 
-    expect(await listaAirdrop.endBlock()).to.equals(newEndBlock);
+    expect(await listaAirdrop.endTime()).to.equals(newEndTime);
   });
 });


### PR DESCRIPTION
* Modified `ListaAirdrop` to use timestamp instead of block number.

To run unit tests:
```shell
npx hardhat test test/listaAirDrop.test.ts
```