### PR TITLE
feat: add whitelist for revenue costTo address

### DIFF
--- a/contracts/dao/ListaRevenueDistributor.sol
+++ b/contracts/dao/ListaRevenueDistributor.sol
@@ -185,13 +185,13 @@ contract ListaRevenueDistributor is Initializable, AccessControlUpgradeable {
     {
         require(tokens.length > 0 && tokens.length == costs.length, "invalid tokens and costs length");
         for (uint256 i = 0; i < tokens.length; i++) {
-            _distributeTokenWithCost(tokens[i], costs[i], tokenCostToAddress);
+            _distributeTokenWithCost(tokens[i], costs[i]);
         }
     }
 
-    function _distributeTokenWithCost(address token, uint256 cost, address costTo) internal {
+    function _distributeTokenWithCost(address token, uint256 cost) internal {
         require(tokenWhitelist[token], "token not whitelisted");
-        require(costTo == tokenCostToAddress || costToWhitelist[costTo], "costTo address not whitelisted");
+        require(tokenCostToAddress != address(0), "reserve address not set");
 
         uint256 balance = IERC20(token).balanceOf(address(this));
         if (balance == 0) {
@@ -199,8 +199,8 @@ contract ListaRevenueDistributor is Initializable, AccessControlUpgradeable {
         }
 
         if (balance <= cost) {
-            IERC20(token).safeTransfer(costTo, balance);
-            emit RevenueDistributedWithCost(token, 0, 0, balance, cost, costTo);
+            IERC20(token).safeTransfer(tokenCostToAddress, balance);
+            emit RevenueDistributedWithCost(token, 0, 0, balance, cost, tokenCostToAddress);
         } else {
             uint256 available = balance - cost;
             uint256 amount0 = available * distributeRate / RATE_DENOMINATOR;
@@ -218,10 +218,10 @@ contract ListaRevenueDistributor is Initializable, AccessControlUpgradeable {
                 IERC20(token).safeTransfer(revenueWalletAddress, amount1);
             }
             if (cost > 0) {
-                IERC20(token).safeTransfer(costTo, cost);
+                IERC20(token).safeTransfer(tokenCostToAddress, cost);
             }
 
-            emit RevenueDistributedWithCost(token, amount0, amount1, cost, cost, costTo);
+            emit RevenueDistributedWithCost(token, amount0, amount1, cost, cost, tokenCostToAddress);
         }
     }
 

--- a/test/dao/ListaRevenueDistributor.t.sol
+++ b/test/dao/ListaRevenueDistributor.t.sol
@@ -174,6 +174,52 @@ contract ListaRevenueDistributorTest is Test {
 
     function test_distributeTokenWithCost() public {
         deal(address(lisUSD), address(listaRevenueDistributor), 123e18);
+
+        assertEq(0, lista.balanceOf(autoBuybackAddress));
+        assertEq(0, lista.balanceOf(revenueWalletAddress));
+        assertEq(0, lista.balanceOf(listaToWalletAddress));
+        assertEq(0, lista.balanceOf(lisUSDCostToAddress));
+
+
+        vm.startPrank(manager);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(lisUSD);
+        uint256[] memory costs = new uint256[](1);
+        costs[0] = 3e18;
+        listaRevenueDistributor.distributeTokensWithCost(tokens, costs);
+        vm.stopPrank();
+
+        assertEq(0, lisUSD.balanceOf(listaToWalletAddress));
+        assertEq(120e18 * 7e17 / 1e18, lisUSD.balanceOf(autoBuybackAddress));
+        assertEq(120e18 - (120e18 * 7e17 / 1e18), lisUSD.balanceOf(revenueWalletAddress));
+        assertEq(3e18, lisUSD.balanceOf(lisUSDCostToAddress));
+    }
+
+    function test_distributeTokenWithCost_all_balance() public {
+        deal(address(lisUSD), address(listaRevenueDistributor), 123e18);
+
+        assertEq(0, lista.balanceOf(autoBuybackAddress));
+        assertEq(0, lista.balanceOf(revenueWalletAddress));
+        assertEq(0, lista.balanceOf(listaToWalletAddress));
+        assertEq(0, lista.balanceOf(lisUSDCostToAddress));
+
+
+        vm.startPrank(manager);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(lisUSD);
+        uint256[] memory costs = new uint256[](1);
+        costs[0] = 125e18;
+        listaRevenueDistributor.distributeTokensWithCost(tokens, costs);
+        vm.stopPrank();
+
+        assertEq(0, lisUSD.balanceOf(listaToWalletAddress));
+        assertEq(0, lisUSD.balanceOf(autoBuybackAddress));
+        assertEq(0, lisUSD.balanceOf(revenueWalletAddress));
+        assertEq(123e18, lisUSD.balanceOf(lisUSDCostToAddress));
+    }
+
+    function test_distributeWithCosts() public {
+        deal(address(lisUSD), address(listaRevenueDistributor), 123e18);
         address costTo = address(0x123456);
 
         assertEq(0, lista.balanceOf(autoBuybackAddress));
@@ -196,7 +242,7 @@ contract ListaRevenueDistributorTest is Test {
         ListaRevenueDistributor.Cost[] memory costs = new ListaRevenueDistributor.Cost[](1);
         costs[0] = _cost;
 
-        listaRevenueDistributor.distributeTokensWithCost(costs);
+        listaRevenueDistributor.distributeWithCosts(costs);
         vm.stopPrank();
 
         assertEq(0, lisUSD.balanceOf(listaToWalletAddress));
@@ -205,7 +251,7 @@ contract ListaRevenueDistributorTest is Test {
         assertEq(3e18, lisUSD.balanceOf(costTo));
     }
 
-    function test_distributeTokenWithCost_all_balance() public {
+    function test_distributeWithCosts_all_balance() public {
         deal(address(lisUSD), address(listaRevenueDistributor), 123e18);
         address costTo = address(0x1234567);
 
@@ -227,10 +273,10 @@ contract ListaRevenueDistributorTest is Test {
         costs[0] = _cost;
 
         vm.expectRevert("costTo address not whitelisted");
-        listaRevenueDistributor.distributeTokensWithCost(costs);
+        listaRevenueDistributor.distributeWithCosts(costs);
 
         listaRevenueDistributor.whitelistCostToAddress(costTo);
-        listaRevenueDistributor.distributeTokensWithCost(costs); // success
+        listaRevenueDistributor.distributeWithCosts(costs); // success
         vm.stopPrank();
 
         assertEq(0, lisUSD.balanceOf(listaToWalletAddress));

--- a/test/dao/ListaRevenueDistributor.t.sol
+++ b/test/dao/ListaRevenueDistributor.t.sol
@@ -241,8 +241,10 @@ contract ListaRevenueDistributorTest is Test {
 
         ListaRevenueDistributor.Cost[] memory costs = new ListaRevenueDistributor.Cost[](1);
         costs[0] = _cost;
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(lisUSD);
 
-        listaRevenueDistributor.distributeWithCosts(costs);
+        listaRevenueDistributor.distributeWithCosts(costs, tokens);
         vm.stopPrank();
 
         assertEq(0, lisUSD.balanceOf(listaToWalletAddress));
@@ -271,12 +273,14 @@ contract ListaRevenueDistributorTest is Test {
 
         ListaRevenueDistributor.Cost[] memory costs = new ListaRevenueDistributor.Cost[](1);
         costs[0] = _cost;
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(lisUSD);
 
         vm.expectRevert("costTo address not whitelisted");
-        listaRevenueDistributor.distributeWithCosts(costs);
+        listaRevenueDistributor.distributeWithCosts(costs, tokens);
 
         listaRevenueDistributor.whitelistCostToAddress(costTo);
-        listaRevenueDistributor.distributeWithCosts(costs); // success
+        listaRevenueDistributor.distributeWithCosts(costs, tokens); // success
         vm.stopPrank();
 
         assertEq(0, lisUSD.balanceOf(listaToWalletAddress));


### PR DESCRIPTION
Currently only one costTo address is support, this PR add a whitelist for costTo address to enable borrowing interests rebate contract to receive `cost`.