### PR TITLE
fea: add free penalty for veLista

### DIFF
--- a/contracts/interfaces/IVeLista.sol
+++ b/contracts/interfaces/IVeLista.sol
@@ -78,4 +78,6 @@ interface IVeLista {
     event EnableAutoLock(address indexed account);
     event PenaltyClaimed(address indexed account, uint256 amount);
     event PenaltyReceiverChanged(address indexed newReceiver);
+    event EarlyClaimBlacklistUpdated(address account, bool isBlacklisted);
+    event FreePenaltyPeriodSet(uint256 start, uint256 end);
 }

--- a/scripts/foundry/dao/deploy_velista_impl.sol
+++ b/scripts/foundry/dao/deploy_velista_impl.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.10;
+
+import { Script, console } from "forge-std/Script.sol";
+
+import { VeLista } from "../../../contracts/VeLista.sol";
+
+contract VeListaDeploy is Script {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        console.log("Deployer: ", deployer);
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Deploy implementation
+        VeLista impl = new VeLista();
+        console.log("Implementation: ", address(impl));
+
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
## 📄 Description
Allow user to earlyClaim without penalty.


## 🧠 Rationale
We want to remove veLista. Upgrade the contract to allow users to withdraw their lista from the contract without incurring any penalties.


## 🧪 Example / Testing
forge test --match-contract VeListaTest -vvv


## 🧬 Changes Summary
Notable changes:
* update contract contracts/VeLista.sol