### PR TITLE
fea: add distributor blacklist to ListaVault

### DIFF
--- a/contracts/dao/ListaVault.sol
+++ b/contracts/dao/ListaVault.sol
@@ -20,14 +20,14 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
 
     using SafeERC20 for IERC20;
 
-    event Deposit(address indexed account, uint256 amount);
-    event Withdraw(address indexed account, uint256 amount);
+    event Deposit(address indexed account, uint16 indexed week, uint256 amount);
     event NewDistributorRegistered(address distributor, uint256 id);
     event EmergencyWithdraw(address token, uint256 amount);
     event Paused(address account);
     event Unpaused(address account);
     event EmissionVotingSet(address emissionVoting);
     event DistributorBlacklistUpdated(uint16 indexed distributorId, bool blacklisted);
+    event WeeklyDistributorPercentSet(uint16 indexed week, uint16[] ids, uint256[] percents);
 
     // lista token address
     IERC20 public token;
@@ -123,7 +123,7 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
         weeklyEmissions[week] += amount;
         token.safeTransferFrom(msg.sender, address(this), amount);
 
-        emit Deposit(msg.sender, amount);
+        emit Deposit(msg.sender, week, amount);
     }
 
     /**
@@ -154,6 +154,8 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
         // mark this week set flag
         weeklyDistributorPercent[week][0] = 1;
         require(totalPercent <= 1e18, "Total percent must be less than or equal to 1e18");
+
+        emit WeeklyDistributorPercentSet(week, ids, percent);
     }
 
     /**

--- a/contracts/dao/ListaVault.sol
+++ b/contracts/dao/ListaVault.sol
@@ -27,6 +27,7 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
     event Paused(address account);
     event Unpaused(address account);
     event EmissionVotingSet(address emissionVoting);
+    event DistributorBlacklistUpdated(uint16 indexed distributorId, bool blacklisted);
 
     // lista token address
     IERC20 public token;
@@ -61,6 +62,8 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
     bool public paused;
     // emission voting address
     IEmissionVoting public emissionVoting;
+    // blacklisted distributor ids — receive zero new emissions
+    mapping(uint16 => bool) public distributorBlacklist;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -142,6 +145,7 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
         }
         for (uint16 i = 0; i < ids.length; ++i) {
             require(idToDistributor[ids[i]] != address(0), "distributor not registered");
+            require(!distributorBlacklist[ids[i]], "distributor blacklisted");
             require(weeklyDistributorPercent[week][ids[i]] == 0, "distributor percent already set");
             weeklyDistributorPercent[week][ids[i]] = percent[i];
             totalPercent += percent[i];
@@ -165,6 +169,20 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
         require(IDistributor(distributor).notifyRegisteredId(distributorId), "distributor registration failed");
         emit NewDistributorRegistered(distributor, distributorId);
         return distributorId;
+    }
+
+    /**
+     * @dev set blacklist state for a distributor id. Blacklisted ids receive
+     *      zero new emissions and cannot be set in setWeeklyDistributorPercent.
+     *      Already-allocated balances are not affected.
+     * @param id distributor id
+     * @param blacklisted true to blacklist, false to remove from blacklist
+     */
+    function setDistributorBlacklist(uint16 id, bool blacklisted) external onlyRole(MANAGER) {
+        require(idToDistributor[id] != address(0), "distributor not registered");
+        require(distributorBlacklist[id] != blacklisted, "blacklist state unchanged");
+        distributorBlacklist[id] = blacklisted;
+        emit DistributorBlacklistUpdated(id, blacklisted);
     }
 
     /**
@@ -260,6 +278,8 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
      * @return emissions
      */
     function getDistributorWeeklyEmissions(uint16 id, uint16 week) public view returns (uint256) {
+        // blacklisted ids receive zero emissions regardless of percent or voting weight
+        if (distributorBlacklist[id]) return 0;
         // emission voting contract not set OR override voting result
         if (emissionVoting == IEmissionVoting(address(0)) || weeklyDistributorPercent[week][0] == 1) {
             uint256 pct = weeklyDistributorPercent[week][id];

--- a/contracts/dao/ListaVault.sol
+++ b/contracts/dao/ListaVault.sol
@@ -283,8 +283,6 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
      * @return emissions
      */
     function getDistributorWeeklyEmissions(uint16 id, uint16 week) public view returns (uint256) {
-        // blacklisted ids receive zero emissions regardless of percent or voting weight
-        if (distributorBlacklist[id]) return 0;
         // emission voting contract not set OR override voting result
         if (emissionVoting == IEmissionVoting(address(0)) || weeklyDistributorPercent[week][0] == 1) {
             uint256 pct = weeklyDistributorPercent[week][id];

--- a/contracts/dao/ListaVault.sol
+++ b/contracts/dao/ListaVault.sol
@@ -172,17 +172,22 @@ contract ListaVault is Initializable, AccessControlUpgradeable, ReentrancyGuardU
     }
 
     /**
-     * @dev set blacklist state for a distributor id. Blacklisted ids receive
+     * @dev batch-set blacklist state for distributor ids. Blacklisted ids receive
      *      zero new emissions and cannot be set in setWeeklyDistributorPercent.
-     *      Already-allocated balances are not affected.
-     * @param id distributor id
-     * @param blacklisted true to blacklist, false to remove from blacklist
+     *      Already-allocated balances are not affected. Ids already in the target
+     *      state are skipped silently (no event); the whole batch is idempotent.
+     * @param ids distributor ids
+     * @param blacklisted true to blacklist all, false to remove all from blacklist
      */
-    function setDistributorBlacklist(uint16 id, bool blacklisted) external onlyRole(MANAGER) {
-        require(idToDistributor[id] != address(0), "distributor not registered");
-        require(distributorBlacklist[id] != blacklisted, "blacklist state unchanged");
-        distributorBlacklist[id] = blacklisted;
-        emit DistributorBlacklistUpdated(id, blacklisted);
+    function batchSetDistributorBlacklist(uint16[] memory ids, bool blacklisted) external onlyRole(MANAGER) {
+        require(ids.length > 0, "ids is empty");
+        for (uint16 i = 0; i < ids.length; ++i) {
+            require(idToDistributor[ids[i]] != address(0), "distributor not registered");
+            if (distributorBlacklist[ids[i]] != blacklisted) {
+                distributorBlacklist[ids[i]] = blacklisted;
+                emit DistributorBlacklistUpdated(ids[i], blacklisted);
+            }
+        }
     }
 
     /**

--- a/test/EmissionVoting.t.sol
+++ b/test/EmissionVoting.t.sol
@@ -82,6 +82,12 @@ contract EmissionVotingTest is Test {
     listaToken.approve(address(vault), type(uint256).max);
     vault.depositRewards(weeklyEmission, veLista.getCurrentWeek() + 1);
     console.logString("Rewards deposited.");
+    // Deployed VeLista enforces freePenaltyPeriodNotStart on lock(); push the
+    // start time past test horizon so locks succeed under the upgraded impl.
+    (bool ok, ) = address(veLista).call(
+      abi.encodeWithSignature("setFreePenaltyPeriod(uint256,uint256)", block.timestamp + 365 days, block.timestamp + 730 days)
+    );
+    require(ok, "setFreePenaltyPeriod failed");
     vm.stopPrank();
 
     deal(address(listaToken), multiSig, 10000e18);

--- a/test/dao/ListaVault.t.sol
+++ b/test/dao/ListaVault.t.sol
@@ -170,53 +170,51 @@ contract ListaVaultTest is Test {
         assertEq(vault.weeklyDistributorPercent(nextWeek, id1), 5e17);
     }
 
-    // ---------- gate: getDistributorWeeklyEmissions ----------
+    // ---------- preserve historical claim ----------
+    //
+    // Blacklist enforcement is at the input (setWeeklyDistributorPercent) only.
+    // getDistributorWeeklyEmissions does NOT short-circuit, so emissions already
+    // earned in past weeks (before the blacklist was set) remain claimable.
 
-    function test_getDistributorWeeklyEmissions_zeroForBlacklistedInPercentPath() public {
-        // operator sets percents, then admin blacklists d1 — emission must be zero
+    function test_allocateNewEmissions_preservesHistoricalAfterBlacklist() public {
+        // OPERATOR sets percent for nextWeek BEFORE blacklist
         uint16 nextWeek = veLista.getCurrentWeek() + 1;
-        uint16[] memory ids = new uint16[](2);
-        uint256[] memory pct = new uint256[](2);
-        ids[0] = id1; pct[0] = 4e17;
-        ids[1] = id2; pct[1] = 6e17;
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1; pct[0] = 1e18; // 100%
 
         vm.prank(operator);
         vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
 
-        // sanity: before blacklist d1 has nonzero allocation
-        assertGt(vault.getDistributorWeeklyEmissions(id1, nextWeek), 0);
+        // advance past nextWeek so the percent matures into a claimable amount
+        vm.warp(block.timestamp + 8 days);
 
+        // NOW blacklist — should not erase the past week's entitlement
         vm.prank(vaultAdmin);
         vault.batchSetDistributorBlacklist(_one(id1), true);
 
-        assertEq(vault.getDistributorWeeklyEmissions(id1, nextWeek), 0);
-        // d2 still gets its share
-        assertGt(vault.getDistributorWeeklyEmissions(id2, nextWeek), 0);
+        uint256 expected = vault.weeklyEmissions(nextWeek);
+        assertGt(expected, 0, "weeklyEmissions sanity");
+
+        vm.prank(address(d1));
+        uint256 got = vault.allocateNewEmissions(id1);
+        assertEq(got, expected, "blacklisted distributor must still claim past-week emissions");
+        assertEq(vault.allocated(address(d1)), expected);
     }
 
-    // ---------- gate: allocateNewEmissions ----------
+    function test_setWeeklyDistributorPercent_blocksFutureWhileBlacklisted() public {
+        // confirm the input gate stops new allocations
+        vm.prank(vaultAdmin);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
-    function test_allocateNewEmissions_zeroForBlacklisted() public {
-        // set d1 percent for next week, advance to that week, then blacklist before allocate
         uint16 nextWeek = veLista.getCurrentWeek() + 1;
         uint16[] memory ids = new uint16[](1);
         uint256[] memory pct = new uint256[](1);
         ids[0] = id1; pct[0] = 1e18;
 
         vm.prank(operator);
+        vm.expectRevert("distributor blacklisted");
         vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
-
-        // jump past nextWeek so allocation has something to credit
-        vm.warp(block.timestamp + 8 days);
-
-        vm.prank(vaultAdmin);
-        vault.batchSetDistributorBlacklist(_one(id1), true);
-
-        // d1 calls allocate; should receive 0
-        vm.prank(address(d1));
-        uint256 got = vault.allocateNewEmissions(id1);
-        assertEq(got, 0);
-        assertEq(vault.allocated(address(d1)), 0);
     }
 
     function test_allocateNewEmissions_nonzeroForNonBlacklisted() public {

--- a/test/dao/ListaVault.t.sol
+++ b/test/dao/ListaVault.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import "../../contracts/VeLista.sol";
+import "../../contracts/ListaToken.sol";
+import "../../contracts/dao/ListaVault.sol";
+import "../../contracts/dao/EmissionVoting.sol";
+import "../../contracts/dao/interfaces/IDistributor.sol";
+
+contract MockDistributor is IDistributor {
+    uint16 public registeredId;
+    function vaultClaimReward(address) external pure returns (uint256) { return 0; }
+    function vaultClaimStakingReward(address) external pure returns (uint256) { return 0; }
+    function notifyRegisteredId(uint16 _emissionId) external returns (bool) {
+        registeredId = _emissionId;
+        return true;
+    }
+    function claimableReward(address) external pure returns (uint256) { return 0; }
+    function notifyStakingReward(uint256) external {}
+    function lpToken() external pure returns (address) { return address(0); }
+}
+
+contract ListaVaultTest is Test {
+    ListaVault public vault = ListaVault(0x307d13267f360f78005f476Fa913F8848F30292A);
+    ListaToken public listaToken = ListaToken(0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46);
+    VeLista public veLista = VeLista(0xd0C380D31DB43CD291E2bbE2Da2fD6dc877b87b3);
+    ProxyAdmin public vaultProxyAdmin = ProxyAdmin(0xd6cd036133cbf6a275B7700fF7B41887A9d5FCAe);
+
+    address timelock = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+    address vaultAdmin = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // MANAGER
+    address operator = makeAddr("operator");
+    address attacker = makeAddr("attacker");
+
+    MockDistributor public d1;
+    MockDistributor public d2;
+    uint16 public id1;
+    uint16 public id2;
+
+    function setUp() public {
+        vm.createSelectFork("https://bsc-dataseed.binance.org");
+
+        // upgrade vault to local impl with blacklist
+        ListaVault impl = new ListaVault();
+        vm.prank(timelock);
+        vaultProxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(vault)),
+            address(impl),
+            bytes("")
+        );
+
+        // grant OPERATOR + register two fresh distributors
+        vm.startPrank(vaultAdmin);
+        vault.grantRole(vault.OPERATOR(), operator);
+        d1 = new MockDistributor();
+        d2 = new MockDistributor();
+        id1 = vault.registerDistributor(address(d1));
+        id2 = vault.registerDistributor(address(d2));
+
+        // fund weekly emissions for next week so getDistributorWeeklyEmissions has a non-zero pool
+        uint16 nextWeek = veLista.getCurrentWeek() + 1;
+        deal(address(listaToken), vaultAdmin, 1000e18);
+        listaToken.approve(address(vault), type(uint256).max);
+        vault.depositRewards(1000e18, nextWeek);
+        vm.stopPrank();
+    }
+
+    // ---------- access control ----------
+
+    function test_setDistributorBlacklist_revertsForNonManager() public {
+        vm.prank(attacker);
+        vm.expectRevert(); // AccessControl reverts with role-specific message
+        vault.setDistributorBlacklist(id1, true);
+    }
+
+    function test_setDistributorBlacklist_managerCanSet() public {
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit ListaVault.DistributorBlacklistUpdated(id1, true);
+
+        vm.prank(vaultAdmin);
+        vault.setDistributorBlacklist(id1, true);
+
+        assertTrue(vault.distributorBlacklist(id1));
+    }
+
+    function test_setDistributorBlacklist_canUnblacklist() public {
+        vm.startPrank(vaultAdmin);
+        vault.setDistributorBlacklist(id1, true);
+        vault.setDistributorBlacklist(id1, false);
+        vm.stopPrank();
+
+        assertFalse(vault.distributorBlacklist(id1));
+    }
+
+    // ---------- validation ----------
+
+    function test_setDistributorBlacklist_revertsOnUnregisteredId() public {
+        uint16 unregisteredId = vault.distributorId() + 1;
+        vm.prank(vaultAdmin);
+        vm.expectRevert("distributor not registered");
+        vault.setDistributorBlacklist(unregisteredId, true);
+    }
+
+    function test_setDistributorBlacklist_revertsWhenStateUnchanged() public {
+        vm.startPrank(vaultAdmin);
+        vm.expectRevert("blacklist state unchanged");
+        vault.setDistributorBlacklist(id1, false); // already false
+
+        vault.setDistributorBlacklist(id1, true);
+        vm.expectRevert("blacklist state unchanged");
+        vault.setDistributorBlacklist(id1, true); // already true
+        vm.stopPrank();
+    }
+
+    // ---------- gate: setWeeklyDistributorPercent ----------
+
+    function test_setWeeklyDistributorPercent_revertsForBlacklistedId() public {
+        vm.prank(vaultAdmin);
+        vault.setDistributorBlacklist(id1, true);
+
+        uint16 nextWeek = veLista.getCurrentWeek() + 1;
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1;
+        pct[0] = 5e17;
+
+        vm.prank(operator);
+        vm.expectRevert("distributor blacklisted");
+        vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
+    }
+
+    function test_setWeeklyDistributorPercent_succeedsAfterUnblacklist() public {
+        vm.startPrank(vaultAdmin);
+        vault.setDistributorBlacklist(id1, true);
+        vault.setDistributorBlacklist(id1, false);
+        vm.stopPrank();
+
+        uint16 nextWeek = veLista.getCurrentWeek() + 1;
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1;
+        pct[0] = 5e17;
+
+        vm.prank(operator);
+        vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
+
+        assertEq(vault.weeklyDistributorPercent(nextWeek, id1), 5e17);
+    }
+
+    // ---------- gate: getDistributorWeeklyEmissions ----------
+
+    function test_getDistributorWeeklyEmissions_zeroForBlacklistedInPercentPath() public {
+        // operator sets percents, then admin blacklists d1 — emission must be zero
+        uint16 nextWeek = veLista.getCurrentWeek() + 1;
+        uint16[] memory ids = new uint16[](2);
+        uint256[] memory pct = new uint256[](2);
+        ids[0] = id1; pct[0] = 4e17;
+        ids[1] = id2; pct[1] = 6e17;
+
+        vm.prank(operator);
+        vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
+
+        // sanity: before blacklist d1 has nonzero allocation
+        assertGt(vault.getDistributorWeeklyEmissions(id1, nextWeek), 0);
+
+        vm.prank(vaultAdmin);
+        vault.setDistributorBlacklist(id1, true);
+
+        assertEq(vault.getDistributorWeeklyEmissions(id1, nextWeek), 0);
+        // d2 still gets its share
+        assertGt(vault.getDistributorWeeklyEmissions(id2, nextWeek), 0);
+    }
+
+    // ---------- gate: allocateNewEmissions ----------
+
+    function test_allocateNewEmissions_zeroForBlacklisted() public {
+        // set d1 percent for next week, advance to that week, then blacklist before allocate
+        uint16 nextWeek = veLista.getCurrentWeek() + 1;
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1; pct[0] = 1e18;
+
+        vm.prank(operator);
+        vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
+
+        // jump past nextWeek so allocation has something to credit
+        vm.warp(block.timestamp + 8 days);
+
+        vm.prank(vaultAdmin);
+        vault.setDistributorBlacklist(id1, true);
+
+        // d1 calls allocate; should receive 0
+        vm.prank(address(d1));
+        uint256 got = vault.allocateNewEmissions(id1);
+        assertEq(got, 0);
+        assertEq(vault.allocated(address(d1)), 0);
+    }
+
+    function test_allocateNewEmissions_nonzeroForNonBlacklisted() public {
+        uint16 nextWeek = veLista.getCurrentWeek() + 1;
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1; pct[0] = 1e18;
+
+        vm.prank(operator);
+        vault.setWeeklyDistributorPercent(nextWeek, ids, pct);
+
+        vm.warp(block.timestamp + 8 days);
+
+        // 100% allocation → distributor receives the full weeklyEmissions pool for that week
+        uint256 expected = vault.weeklyEmissions(nextWeek);
+        assertGt(expected, 0, "weeklyEmissions sanity");
+
+        vm.prank(address(d1));
+        uint256 got = vault.allocateNewEmissions(id1);
+        assertEq(got, expected);
+        assertEq(vault.allocated(address(d1)), expected);
+    }
+}

--- a/test/dao/ListaVault.t.sol
+++ b/test/dao/ListaVault.t.sol
@@ -70,48 +70,68 @@ contract ListaVaultTest is Test {
 
     // ---------- access control ----------
 
-    function test_setDistributorBlacklist_revertsForNonManager() public {
+    function test_batchSetDistributorBlacklist_revertsForNonManager() public {
         vm.prank(attacker);
         vm.expectRevert(); // AccessControl reverts with role-specific message
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
     }
 
-    function test_setDistributorBlacklist_managerCanSet() public {
+    function test_batchSetDistributorBlacklist_managerCanSet() public {
         vm.expectEmit(true, false, false, true, address(vault));
         emit ListaVault.DistributorBlacklistUpdated(id1, true);
 
         vm.prank(vaultAdmin);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         assertTrue(vault.distributorBlacklist(id1));
     }
 
-    function test_setDistributorBlacklist_canUnblacklist() public {
+    function test_batchSetDistributorBlacklist_canUnblacklist() public {
         vm.startPrank(vaultAdmin);
-        vault.setDistributorBlacklist(id1, true);
-        vault.setDistributorBlacklist(id1, false);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+        vault.batchSetDistributorBlacklist(_one(id1), false);
         vm.stopPrank();
 
         assertFalse(vault.distributorBlacklist(id1));
     }
 
+    function test_batchSetDistributorBlacklist_appliesToAllIds() public {
+        uint16[] memory ids = new uint16[](2);
+        ids[0] = id1;
+        ids[1] = id2;
+
+        vm.prank(vaultAdmin);
+        vault.batchSetDistributorBlacklist(ids, true);
+
+        assertTrue(vault.distributorBlacklist(id1));
+        assertTrue(vault.distributorBlacklist(id2));
+    }
+
     // ---------- validation ----------
 
-    function test_setDistributorBlacklist_revertsOnUnregisteredId() public {
+    function test_batchSetDistributorBlacklist_revertsOnEmptyArray() public {
+        uint16[] memory ids = new uint16[](0);
+        vm.prank(vaultAdmin);
+        vm.expectRevert("ids is empty");
+        vault.batchSetDistributorBlacklist(ids, true);
+    }
+
+    function test_batchSetDistributorBlacklist_revertsOnUnregisteredId() public {
         uint16 unregisteredId = vault.distributorId() + 1;
         vm.prank(vaultAdmin);
         vm.expectRevert("distributor not registered");
-        vault.setDistributorBlacklist(unregisteredId, true);
+        vault.batchSetDistributorBlacklist(_one(unregisteredId), true);
     }
 
-    function test_setDistributorBlacklist_revertsWhenStateUnchanged() public {
+    function test_batchSetDistributorBlacklist_skipsNoOpIdsSilently() public {
+        // ids already in target state are skipped — no revert, no event
         vm.startPrank(vaultAdmin);
-        vm.expectRevert("blacklist state unchanged");
-        vault.setDistributorBlacklist(id1, false); // already false
+        vault.batchSetDistributorBlacklist(_one(id1), false); // already false → silent
+        assertFalse(vault.distributorBlacklist(id1));
 
-        vault.setDistributorBlacklist(id1, true);
-        vm.expectRevert("blacklist state unchanged");
-        vault.setDistributorBlacklist(id1, true); // already true
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);  // already true → silent
+        assertTrue(vault.distributorBlacklist(id1));
         vm.stopPrank();
     }
 
@@ -119,7 +139,7 @@ contract ListaVaultTest is Test {
 
     function test_setWeeklyDistributorPercent_revertsForBlacklistedId() public {
         vm.prank(vaultAdmin);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         uint16 nextWeek = veLista.getCurrentWeek() + 1;
         uint16[] memory ids = new uint16[](1);
@@ -134,8 +154,8 @@ contract ListaVaultTest is Test {
 
     function test_setWeeklyDistributorPercent_succeedsAfterUnblacklist() public {
         vm.startPrank(vaultAdmin);
-        vault.setDistributorBlacklist(id1, true);
-        vault.setDistributorBlacklist(id1, false);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+        vault.batchSetDistributorBlacklist(_one(id1), false);
         vm.stopPrank();
 
         uint16 nextWeek = veLista.getCurrentWeek() + 1;
@@ -167,7 +187,7 @@ contract ListaVaultTest is Test {
         assertGt(vault.getDistributorWeeklyEmissions(id1, nextWeek), 0);
 
         vm.prank(vaultAdmin);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         assertEq(vault.getDistributorWeeklyEmissions(id1, nextWeek), 0);
         // d2 still gets its share
@@ -190,7 +210,7 @@ contract ListaVaultTest is Test {
         vm.warp(block.timestamp + 8 days);
 
         vm.prank(vaultAdmin);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         // d1 calls allocate; should receive 0
         vm.prank(address(d1));
@@ -218,5 +238,12 @@ contract ListaVaultTest is Test {
         uint256 got = vault.allocateNewEmissions(id1);
         assertEq(got, expected);
         assertEq(vault.allocated(address(d1)), expected);
+    }
+
+    // ---------- helpers ----------
+
+    function _one(uint16 id) internal pure returns (uint16[] memory a) {
+        a = new uint16[](1);
+        a[0] = id;
     }
 }

--- a/test/dao/ListaVaultUnit.t.sol
+++ b/test/dao/ListaVaultUnit.t.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import "../../contracts/dao/ListaVault.sol";
+import "../../contracts/dao/interfaces/IDistributor.sol";
+
+contract MockVeListaForVault {
+    uint16 public currentWeek;
+    function getCurrentWeek() external view returns (uint16) { return currentWeek; }
+    function startTime() external pure returns (uint256) { return 1; }
+    function getWeek(uint256) external view returns (uint16) { return currentWeek; }
+    function setCurrentWeek(uint16 _w) external { currentWeek = _w; }
+}
+
+contract MockEmissionVoting {
+    mapping(uint16 => uint256) public weeklyTotalWeight;
+    mapping(uint16 => mapping(uint16 => uint256)) public distributorWeight;
+    function getWeeklyTotalWeight(uint16 week) external view returns (uint256) {
+        return weeklyTotalWeight[week];
+    }
+    function getDistributorWeeklyTotalWeight(uint16 id, uint16 week) external view returns (uint256) {
+        return distributorWeight[id][week];
+    }
+    function setWeights(uint16 week, uint256 total, uint16 id1, uint256 w1, uint16 id2, uint256 w2) external {
+        weeklyTotalWeight[week] = total;
+        distributorWeight[id1][week] = w1;
+        distributorWeight[id2][week] = w2;
+    }
+}
+
+contract MockUnitDistributor is IDistributor {
+    function vaultClaimReward(address) external pure returns (uint256) { return 0; }
+    function vaultClaimStakingReward(address) external pure returns (uint256) { return 0; }
+    function notifyRegisteredId(uint16) external pure returns (bool) { return true; }
+    function claimableReward(address) external pure returns (uint256) { return 0; }
+    function notifyStakingReward(uint256) external {}
+    function lpToken() external pure returns (address) { return address(0); }
+}
+
+// Minimal ERC20 with public mint — avoids the existing MockERC20's onlyMinter gate.
+contract TestToken {
+    string public name = "TestLISTA";
+    string public symbol = "TLISTA";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amt) external { balanceOf[to] += amt; totalSupply += amt; }
+    function approve(address sp, uint256 amt) external returns (bool) { allowance[msg.sender][sp] = amt; return true; }
+    function transfer(address to, uint256 amt) external returns (bool) {
+        balanceOf[msg.sender] -= amt; balanceOf[to] += amt; return true;
+    }
+    function transferFrom(address from, address to, uint256 amt) external returns (bool) {
+        if (allowance[from][msg.sender] != type(uint256).max) allowance[from][msg.sender] -= amt;
+        balanceOf[from] -= amt; balanceOf[to] += amt; return true;
+    }
+}
+
+contract ListaVaultUnitTest is Test {
+    ListaVault vault;
+    TestToken lista;
+    MockVeListaForVault veLista;
+    MockEmissionVoting emissionVoting;
+    MockUnitDistributor d1;
+    MockUnitDistributor d2;
+
+    address admin    = makeAddr("admin");
+    address manager  = makeAddr("manager");
+    address operator = makeAddr("operator");
+    address attacker = makeAddr("attacker");
+
+    uint16 id1;
+    uint16 id2;
+
+    uint16 constant CURRENT_WEEK = 10;
+    uint16 constant NEXT_WEEK = 11;
+
+    function setUp() public {
+        lista = new TestToken();
+        veLista = new MockVeListaForVault();
+        veLista.setCurrentWeek(CURRENT_WEEK);
+        emissionVoting = new MockEmissionVoting();
+
+        ListaVault impl = new ListaVault();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(ListaVault.initialize, (admin, manager, address(lista), address(veLista)))
+        );
+        vault = ListaVault(address(proxy));
+
+        vm.startPrank(admin);
+        vault.grantRole(vault.OPERATOR(), operator);
+        vm.stopPrank();
+
+        d1 = new MockUnitDistributor();
+        d2 = new MockUnitDistributor();
+        vm.startPrank(manager);
+        id1 = vault.registerDistributor(address(d1));
+        id2 = vault.registerDistributor(address(d2));
+        vm.stopPrank();
+
+        // fund 1000 LISTA emissions for NEXT_WEEK
+        lista.mint(operator, 1000e18);
+        vm.startPrank(operator);
+        lista.approve(address(vault), type(uint256).max);
+        vault.depositRewards(1000e18, NEXT_WEEK);
+        vm.stopPrank();
+    }
+
+    // ---------- access control ----------
+
+    function test_setDistributorBlacklist_revertsForNonManager() public {
+        vm.prank(attacker);
+        vm.expectRevert();
+        vault.setDistributorBlacklist(id1, true);
+    }
+
+    function test_setDistributorBlacklist_revertsForAdminWithoutManager() public {
+        // admin has DEFAULT_ADMIN_ROLE only, not MANAGER
+        vm.prank(admin);
+        vm.expectRevert();
+        vault.setDistributorBlacklist(id1, true);
+    }
+
+    function test_setDistributorBlacklist_managerSucceeds() public {
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit ListaVault.DistributorBlacklistUpdated(id1, true);
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+        assertTrue(vault.distributorBlacklist(id1));
+    }
+
+    // ---------- validation ----------
+
+    function test_setDistributorBlacklist_revertsOnUnregisteredId() public {
+        uint16 unregistered = vault.distributorId() + 1;
+        vm.prank(manager);
+        vm.expectRevert("distributor not registered");
+        vault.setDistributorBlacklist(unregistered, true);
+    }
+
+    function test_setDistributorBlacklist_revertsOnZeroId() public {
+        vm.prank(manager);
+        vm.expectRevert("distributor not registered");
+        vault.setDistributorBlacklist(0, true);
+    }
+
+    function test_setDistributorBlacklist_revertsOnNoOp() public {
+        vm.startPrank(manager);
+        vm.expectRevert("blacklist state unchanged");
+        vault.setDistributorBlacklist(id1, false); // already false
+
+        vault.setDistributorBlacklist(id1, true);
+        vm.expectRevert("blacklist state unchanged");
+        vault.setDistributorBlacklist(id1, true);  // already true
+        vm.stopPrank();
+    }
+
+    function test_setDistributorBlacklist_toggleEmitsEachEvent() public {
+        vm.startPrank(manager);
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit ListaVault.DistributorBlacklistUpdated(id1, true);
+        vault.setDistributorBlacklist(id1, true);
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit ListaVault.DistributorBlacklistUpdated(id1, false);
+        vault.setDistributorBlacklist(id1, false);
+
+        vm.stopPrank();
+        assertFalse(vault.distributorBlacklist(id1));
+    }
+
+    // ---------- gate: setWeeklyDistributorPercent ----------
+
+    function test_setWeeklyDistributorPercent_revertsIfAnyIdBlacklisted() public {
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id2, true);
+
+        uint16[] memory ids = new uint16[](2);
+        uint256[] memory pct = new uint256[](2);
+        ids[0] = id1; pct[0] = 4e17;
+        ids[1] = id2; pct[1] = 6e17;
+
+        vm.prank(operator);
+        vm.expectRevert("distributor blacklisted");
+        vault.setWeeklyDistributorPercent(NEXT_WEEK, ids, pct);
+    }
+
+    function test_setWeeklyDistributorPercent_revertsOnFirstBlacklisted() public {
+        // blacklist id1 — first iteration must revert before id2 is checked
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+
+        uint16[] memory ids = new uint16[](2);
+        uint256[] memory pct = new uint256[](2);
+        ids[0] = id1; pct[0] = 4e17;
+        ids[1] = id2; pct[1] = 6e17;
+
+        vm.prank(operator);
+        vm.expectRevert("distributor blacklisted");
+        vault.setWeeklyDistributorPercent(NEXT_WEEK, ids, pct);
+    }
+
+    function test_setWeeklyDistributorPercent_succeedsAfterUnblacklist() public {
+        vm.startPrank(manager);
+        vault.setDistributorBlacklist(id1, true);
+        vault.setDistributorBlacklist(id1, false);
+        vm.stopPrank();
+
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1; pct[0] = 5e17;
+
+        vm.prank(operator);
+        vault.setWeeklyDistributorPercent(NEXT_WEEK, ids, pct);
+        assertEq(vault.weeklyDistributorPercent(NEXT_WEEK, id1), 5e17);
+    }
+
+    // ---------- gate: getDistributorWeeklyEmissions, no emissionVoting ----------
+
+    function test_getDistributorWeeklyEmissions_zeroForBlacklistedNoVoting() public {
+        _setPercents(id1, 4e17, id2, 6e17);
+
+        // sanity before blacklist
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
+        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
+
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
+        // d2's share is unchanged — leftover stays in vault
+        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
+    }
+
+    // ---------- gate: getDistributorWeeklyEmissions, voting set + percent override ----------
+
+    function test_getDistributorWeeklyEmissions_zeroForBlacklistedWithPercentOverride() public {
+        // emissionVoting set, but operator also set percents — override path
+        vm.prank(admin);
+        vault.setEmissionVoting(address(emissionVoting));
+        _setPercents(id1, 4e17, id2, 6e17);
+        // weights set so we can prove blacklist takes priority over voting too
+        emissionVoting.setWeights(NEXT_WEEK, 1000, id1, 500, id2, 500);
+
+        // override path active (weeklyDistributorPercent[NEXT_WEEK][0] == 1)
+        // d1 should still receive percent-based amount
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
+
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
+    }
+
+    // ---------- gate: getDistributorWeeklyEmissions, voting path ----------
+
+    function test_getDistributorWeeklyEmissions_zeroForBlacklistedInVotingPath() public {
+        vm.prank(admin);
+        vault.setEmissionVoting(address(emissionVoting));
+        // do NOT call setWeeklyDistributorPercent — voting path is active
+        emissionVoting.setWeights(NEXT_WEEK, 1000, id1, 400, id2, 600);
+
+        // sanity: voting path returns weight-proportional amount
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
+        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
+
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
+        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
+    }
+
+    // ---------- downstream: allocateNewEmissions ----------
+
+    function test_allocateNewEmissions_zeroForBlacklisted() public {
+        _setPercents(id1, 1e18, id2, 0); // d1 gets 100%
+
+        // advance to NEXT_WEEK so allocate has something to credit
+        veLista.setCurrentWeek(NEXT_WEEK);
+
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+
+        vm.prank(address(d1));
+        uint256 got = vault.allocateNewEmissions(id1);
+        assertEq(got, 0);
+        assertEq(vault.allocated(address(d1)), 0);
+    }
+
+    function test_allocateNewEmissions_unblacklistRestoresFutureFlow() public {
+        _setPercents(id1, 1e18, id2, 0);
+
+        // week W+1: blacklist active; advance and allocate → 0
+        veLista.setCurrentWeek(NEXT_WEEK);
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, true);
+        vm.prank(address(d1));
+        assertEq(vault.allocateNewEmissions(id1), 0);
+
+        // unblacklist — but distributorUpdatedWeek already moved to NEXT_WEEK, so
+        // already-skipped emissions stay skipped (intended: blacklist at allocate
+        // time wins). Future weeks would flow normally; this test just confirms
+        // the state machine doesn't double-credit retroactively.
+        vm.prank(manager);
+        vault.setDistributorBlacklist(id1, false);
+        vm.prank(address(d1));
+        assertEq(vault.allocateNewEmissions(id1), 0); // same week, nothing new
+
+        // fund + allocate for a later week to confirm flow restored
+        lista.mint(operator, 500e18);
+        vm.startPrank(operator);
+        vault.depositRewards(500e18, NEXT_WEEK + 1);
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1; pct[0] = 1e18;
+        vault.setWeeklyDistributorPercent(NEXT_WEEK + 1, ids, pct);
+        vm.stopPrank();
+
+        veLista.setCurrentWeek(NEXT_WEEK + 1);
+        vm.prank(address(d1));
+        assertEq(vault.allocateNewEmissions(id1), 500e18);
+    }
+
+    // ---------- helper ----------
+
+    function _setPercents(uint16 _id1, uint256 p1, uint16 _id2, uint256 p2) internal {
+        uint256 n;
+        if (p1 > 0) n++;
+        if (p2 > 0) n++;
+        uint16[] memory ids = new uint16[](n);
+        uint256[] memory pct = new uint256[](n);
+        uint256 j;
+        if (p1 > 0) { ids[j] = _id1; pct[j] = p1; j++; }
+        if (p2 > 0) { ids[j] = _id2; pct[j] = p2; j++; }
+        vm.prank(operator);
+        vault.setWeeklyDistributorPercent(NEXT_WEEK, ids, pct);
+    }
+}

--- a/test/dao/ListaVaultUnit.t.sol
+++ b/test/dao/ListaVaultUnit.t.sol
@@ -113,63 +113,106 @@ contract ListaVaultUnitTest is Test {
 
     // ---------- access control ----------
 
-    function test_setDistributorBlacklist_revertsForNonManager() public {
+    function test_batchSetDistributorBlacklist_revertsForNonManager() public {
         vm.prank(attacker);
         vm.expectRevert();
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
     }
 
-    function test_setDistributorBlacklist_revertsForAdminWithoutManager() public {
+    function test_batchSetDistributorBlacklist_revertsForAdminWithoutManager() public {
         // admin has DEFAULT_ADMIN_ROLE only, not MANAGER
         vm.prank(admin);
         vm.expectRevert();
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
     }
 
-    function test_setDistributorBlacklist_managerSucceeds() public {
+    function test_batchSetDistributorBlacklist_managerSucceeds() public {
         vm.expectEmit(true, false, false, true, address(vault));
         emit ListaVault.DistributorBlacklistUpdated(id1, true);
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
         assertTrue(vault.distributorBlacklist(id1));
+    }
+
+    function test_batchSetDistributorBlacklist_appliesToAllIds() public {
+        uint16[] memory ids = new uint16[](2);
+        ids[0] = id1;
+        ids[1] = id2;
+        vm.prank(manager);
+        vault.batchSetDistributorBlacklist(ids, true);
+        assertTrue(vault.distributorBlacklist(id1));
+        assertTrue(vault.distributorBlacklist(id2));
+    }
+
+    function test_batchSetDistributorBlacklist_partialNoOpEmitsOnlyForChanged() public {
+        // pre-blacklist id1 → only id2 should change in the next batch
+        vm.startPrank(manager);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+
+        uint16[] memory ids = new uint16[](2);
+        ids[0] = id1; // already true → silent
+        ids[1] = id2; // false → true → event
+
+        vm.recordLogs();
+        vault.batchSetDistributorBlacklist(ids, true);
+        vm.stopPrank();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        // exactly one DistributorBlacklistUpdated event in this call
+        bytes32 sig = keccak256("DistributorBlacklistUpdated(uint16,bool)");
+        uint256 hits;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == sig) hits++;
+        }
+        assertEq(hits, 1, "expected exactly 1 event for the changed id");
+        assertTrue(vault.distributorBlacklist(id1));
+        assertTrue(vault.distributorBlacklist(id2));
     }
 
     // ---------- validation ----------
 
-    function test_setDistributorBlacklist_revertsOnUnregisteredId() public {
+    function test_batchSetDistributorBlacklist_revertsOnEmptyArray() public {
+        uint16[] memory ids = new uint16[](0);
+        vm.prank(manager);
+        vm.expectRevert("ids is empty");
+        vault.batchSetDistributorBlacklist(ids, true);
+    }
+
+    function test_batchSetDistributorBlacklist_revertsOnUnregisteredId() public {
         uint16 unregistered = vault.distributorId() + 1;
         vm.prank(manager);
         vm.expectRevert("distributor not registered");
-        vault.setDistributorBlacklist(unregistered, true);
+        vault.batchSetDistributorBlacklist(_one(unregistered), true);
     }
 
-    function test_setDistributorBlacklist_revertsOnZeroId() public {
+    function test_batchSetDistributorBlacklist_revertsOnZeroId() public {
         vm.prank(manager);
         vm.expectRevert("distributor not registered");
-        vault.setDistributorBlacklist(0, true);
+        vault.batchSetDistributorBlacklist(_one(0), true);
     }
 
-    function test_setDistributorBlacklist_revertsOnNoOp() public {
+    function test_batchSetDistributorBlacklist_skipsNoOpsSilently() public {
+        // ids already in target state are skipped — no revert
         vm.startPrank(manager);
-        vm.expectRevert("blacklist state unchanged");
-        vault.setDistributorBlacklist(id1, false); // already false
+        vault.batchSetDistributorBlacklist(_one(id1), false); // already false → silent
+        assertFalse(vault.distributorBlacklist(id1));
 
-        vault.setDistributorBlacklist(id1, true);
-        vm.expectRevert("blacklist state unchanged");
-        vault.setDistributorBlacklist(id1, true);  // already true
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);  // already true → silent
+        assertTrue(vault.distributorBlacklist(id1));
         vm.stopPrank();
     }
 
-    function test_setDistributorBlacklist_toggleEmitsEachEvent() public {
+    function test_batchSetDistributorBlacklist_toggleEmitsEachStateChange() public {
         vm.startPrank(manager);
 
         vm.expectEmit(true, false, false, true, address(vault));
         emit ListaVault.DistributorBlacklistUpdated(id1, true);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         vm.expectEmit(true, false, false, true, address(vault));
         emit ListaVault.DistributorBlacklistUpdated(id1, false);
-        vault.setDistributorBlacklist(id1, false);
+        vault.batchSetDistributorBlacklist(_one(id1), false);
 
         vm.stopPrank();
         assertFalse(vault.distributorBlacklist(id1));
@@ -179,7 +222,7 @@ contract ListaVaultUnitTest is Test {
 
     function test_setWeeklyDistributorPercent_revertsIfAnyIdBlacklisted() public {
         vm.prank(manager);
-        vault.setDistributorBlacklist(id2, true);
+        vault.batchSetDistributorBlacklist(_one(id2), true);
 
         uint16[] memory ids = new uint16[](2);
         uint256[] memory pct = new uint256[](2);
@@ -194,7 +237,7 @@ contract ListaVaultUnitTest is Test {
     function test_setWeeklyDistributorPercent_revertsOnFirstBlacklisted() public {
         // blacklist id1 — first iteration must revert before id2 is checked
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         uint16[] memory ids = new uint16[](2);
         uint256[] memory pct = new uint256[](2);
@@ -208,8 +251,8 @@ contract ListaVaultUnitTest is Test {
 
     function test_setWeeklyDistributorPercent_succeedsAfterUnblacklist() public {
         vm.startPrank(manager);
-        vault.setDistributorBlacklist(id1, true);
-        vault.setDistributorBlacklist(id1, false);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+        vault.batchSetDistributorBlacklist(_one(id1), false);
         vm.stopPrank();
 
         uint16[] memory ids = new uint16[](1);
@@ -231,7 +274,7 @@ contract ListaVaultUnitTest is Test {
         assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
 
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
         // d2's share is unchanged — leftover stays in vault
@@ -253,7 +296,7 @@ contract ListaVaultUnitTest is Test {
         assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
 
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
     }
@@ -271,7 +314,7 @@ contract ListaVaultUnitTest is Test {
         assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
 
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
         assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
@@ -286,7 +329,7 @@ contract ListaVaultUnitTest is Test {
         veLista.setCurrentWeek(NEXT_WEEK);
 
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
 
         vm.prank(address(d1));
         uint256 got = vault.allocateNewEmissions(id1);
@@ -300,7 +343,7 @@ contract ListaVaultUnitTest is Test {
         // week W+1: blacklist active; advance and allocate → 0
         veLista.setCurrentWeek(NEXT_WEEK);
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, true);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
         vm.prank(address(d1));
         assertEq(vault.allocateNewEmissions(id1), 0);
 
@@ -309,7 +352,7 @@ contract ListaVaultUnitTest is Test {
         // time wins). Future weeks would flow normally; this test just confirms
         // the state machine doesn't double-credit retroactively.
         vm.prank(manager);
-        vault.setDistributorBlacklist(id1, false);
+        vault.batchSetDistributorBlacklist(_one(id1), false);
         vm.prank(address(d1));
         assertEq(vault.allocateNewEmissions(id1), 0); // same week, nothing new
 
@@ -341,5 +384,10 @@ contract ListaVaultUnitTest is Test {
         if (p2 > 0) { ids[j] = _id2; pct[j] = p2; j++; }
         vm.prank(operator);
         vault.setWeeklyDistributorPercent(NEXT_WEEK, ids, pct);
+    }
+
+    function _one(uint16 id) internal pure returns (uint16[] memory a) {
+        a = new uint16[](1);
+        a[0] = id;
     }
 }

--- a/test/dao/ListaVaultUnit.t.sol
+++ b/test/dao/ListaVaultUnit.t.sol
@@ -264,101 +264,90 @@ contract ListaVaultUnitTest is Test {
         assertEq(vault.weeklyDistributorPercent(NEXT_WEEK, id1), 5e17);
     }
 
-    // ---------- gate: getDistributorWeeklyEmissions, no emissionVoting ----------
+    // ---------- preserve historical entitlement ----------
+    //
+    // Blacklist enforcement is at the input only — setWeeklyDistributorPercent
+    // reverts on blacklisted ids. getDistributorWeeklyEmissions does NOT
+    // short-circuit, so emissions allocated in past weeks remain claimable.
 
-    function test_getDistributorWeeklyEmissions_zeroForBlacklistedNoVoting() public {
+    function test_getDistributorWeeklyEmissions_returnsHistoricalAfterBlacklist_percentPath() public {
         _setPercents(id1, 4e17, id2, 6e17);
-
-        // sanity before blacklist
-        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
-        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
-
-        vm.prank(manager);
-        vault.batchSetDistributorBlacklist(_one(id1), true);
-
-        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
-        // d2's share is unchanged — leftover stays in vault
-        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
-    }
-
-    // ---------- gate: getDistributorWeeklyEmissions, voting set + percent override ----------
-
-    function test_getDistributorWeeklyEmissions_zeroForBlacklistedWithPercentOverride() public {
-        // emissionVoting set, but operator also set percents — override path
-        vm.prank(admin);
-        vault.setEmissionVoting(address(emissionVoting));
-        _setPercents(id1, 4e17, id2, 6e17);
-        // weights set so we can prove blacklist takes priority over voting too
-        emissionVoting.setWeights(NEXT_WEEK, 1000, id1, 500, id2, 500);
-
-        // override path active (weeklyDistributorPercent[NEXT_WEEK][0] == 1)
-        // d1 should still receive percent-based amount
         assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
 
         vm.prank(manager);
         vault.batchSetDistributorBlacklist(_one(id1), true);
 
-        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
+        // historical percent stays claimable
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
+        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
     }
 
-    // ---------- gate: getDistributorWeeklyEmissions, voting path ----------
-
-    function test_getDistributorWeeklyEmissions_zeroForBlacklistedInVotingPath() public {
+    function test_getDistributorWeeklyEmissions_returnsHistoricalAfterBlacklist_votingPath() public {
         vm.prank(admin);
         vault.setEmissionVoting(address(emissionVoting));
-        // do NOT call setWeeklyDistributorPercent — voting path is active
         emissionVoting.setWeights(NEXT_WEEK, 1000, id1, 400, id2, 600);
 
-        // sanity: voting path returns weight-proportional amount
         assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
-        assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
 
         vm.prank(manager);
         vault.batchSetDistributorBlacklist(_one(id1), true);
 
-        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 0);
+        // voting-path entitlement also preserved — voters' choice prevails
+        assertEq(vault.getDistributorWeeklyEmissions(id1, NEXT_WEEK), 400e18);
         assertEq(vault.getDistributorWeeklyEmissions(id2, NEXT_WEEK), 600e18);
     }
 
     // ---------- downstream: allocateNewEmissions ----------
 
-    function test_allocateNewEmissions_zeroForBlacklisted() public {
-        _setPercents(id1, 1e18, id2, 0); // d1 gets 100%
+    function test_allocateNewEmissions_preservesHistoricalAfterBlacklist() public {
+        // OPERATOR sets percent BEFORE blacklist
+        _setPercents(id1, 1e18, id2, 0);
 
-        // advance to NEXT_WEEK so allocate has something to credit
+        // advance and blacklist — past entitlement must still flow
         veLista.setCurrentWeek(NEXT_WEEK);
-
         vm.prank(manager);
         vault.batchSetDistributorBlacklist(_one(id1), true);
 
         vm.prank(address(d1));
         uint256 got = vault.allocateNewEmissions(id1);
-        assertEq(got, 0);
-        assertEq(vault.allocated(address(d1)), 0);
+        assertEq(got, 1000e18, "blacklisted distributor must still claim past-week emissions");
+        assertEq(vault.allocated(address(d1)), 1000e18);
     }
 
-    function test_allocateNewEmissions_unblacklistRestoresFutureFlow() public {
-        _setPercents(id1, 1e18, id2, 0);
-
-        // week W+1: blacklist active; advance and allocate → 0
-        veLista.setCurrentWeek(NEXT_WEEK);
+    function test_blacklist_blocksFutureWeeksViaInputGate() public {
+        // blacklist d1 — OPERATOR cannot set future percents for it
         vm.prank(manager);
         vault.batchSetDistributorBlacklist(_one(id1), true);
-        vm.prank(address(d1));
-        assertEq(vault.allocateNewEmissions(id1), 0);
 
-        // unblacklist — but distributorUpdatedWeek already moved to NEXT_WEEK, so
-        // already-skipped emissions stay skipped (intended: blacklist at allocate
-        // time wins). Future weeks would flow normally; this test just confirms
-        // the state machine doesn't double-credit retroactively.
-        vm.prank(manager);
-        vault.batchSetDistributorBlacklist(_one(id1), false);
-        vm.prank(address(d1));
-        assertEq(vault.allocateNewEmissions(id1), 0); // same week, nothing new
-
-        // fund + allocate for a later week to confirm flow restored
+        // fund and try to set percent for the *next* future week → reverts at input
         lista.mint(operator, 500e18);
         vm.startPrank(operator);
+        lista.approve(address(vault), type(uint256).max);
+        vault.depositRewards(500e18, NEXT_WEEK + 1);
+
+        uint16[] memory ids = new uint16[](1);
+        uint256[] memory pct = new uint256[](1);
+        ids[0] = id1; pct[0] = 1e18;
+        vm.expectRevert("distributor blacklisted");
+        vault.setWeeklyDistributorPercent(NEXT_WEEK + 1, ids, pct);
+        vm.stopPrank();
+
+        // since percent never got set, future allocate returns 0 for d1
+        veLista.setCurrentWeek(NEXT_WEEK + 1);
+        vm.prank(address(d1));
+        assertEq(vault.allocateNewEmissions(id1), 0);
+    }
+
+    function test_unblacklist_restoresFutureFlow() public {
+        // blacklist then unblacklist — OPERATOR can again set percents
+        vm.startPrank(manager);
+        vault.batchSetDistributorBlacklist(_one(id1), true);
+        vault.batchSetDistributorBlacklist(_one(id1), false);
+        vm.stopPrank();
+
+        lista.mint(operator, 500e18);
+        vm.startPrank(operator);
+        lista.approve(address(vault), type(uint256).max);
         vault.depositRewards(500e18, NEXT_WEEK + 1);
         uint16[] memory ids = new uint16[](1);
         uint256[] memory pct = new uint256[](1);


### PR DESCRIPTION
## Summary

Adds a MANAGER-controlled blacklist on `ListaVault` so that specific `distributorId`s can be cut off from **new** emissions without un-registering them. Already-allocated balances and unclaimed historical entitlements remain claimable. Includes one independent test-only fix that unblocks `EmissionVoting.t.sol` under the deployed VeLista's new `freePenaltyPeriodNotStart` modifier. Also folds in event-level cleanups surfaced by the external audit (I04/I05).

## Change type

- [ ] New contract
- [x] Upgrade (existing proxy)
- [x] Bug fix *(test fix only — `test/EmissionVoting.t.sol`)*
- [ ] Gas optimization
- [ ] Configuration change
- [ ] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|---|---|---|
| ListaVault | `contracts/dao/ListaVault.sol` | modified |
| ListaVaultTest | `test/dao/ListaVault.t.sol` | new (fork-based) |
| ListaVaultUnitTest | `test/dao/ListaVaultUnit.t.sol` | new (pure unit) |
| EmissionVotingTest | `test/EmissionVoting.t.sol` | modified (test fix) |

## Interface changes

**New external function** (MANAGER-only, batch):
```solidity
function batchSetDistributorBlacklist(uint16[] memory ids, bool blacklisted) external onlyRole(MANAGER);
```
- reverts `"ids is empty"` if `ids.length == 0`
- reverts `"distributor not registered"` if any `idToDistributor[ids[i]] == address(0)` (also rejects id=0)
- ids already in the target state are skipped silently (no event) — call is idempotent

**New event:**
```solidity
event DistributorBlacklistUpdated(uint16 indexed distributorId, bool blacklisted);
```
Emitted once per id whose state actually changed.

**New public storage getter:** `distributorBlacklist(uint16) → bool`.

**Modified behavior:**
- `setWeeklyDistributorPercent(...)` — additionally reverts with `"distributor blacklisted"` if any id in the input array is blacklisted. **This is the only enforcement gate** — it stops new percents from being recorded for blacklisted ids.
- `getDistributorWeeklyEmissions(...)` and `allocateNewEmissions(...)` — **unchanged**. Historical `weeklyDistributorPercent[week][id]` entries set before a blacklist remain claimable; the distributor can still call `allocateNewEmissions` and receive past-week amounts. (Voting-path emissions are also preserved — voter-driven allocations are a governance concern, not blocked here.)

### Event changes (audit follow-up — I04 / I05)

- `event Withdraw(address indexed, uint256)` — **removed** (was declared but never emitted; I04).
- `event Deposit(address indexed account, uint256 amount)` → `event Deposit(address indexed account, uint16 indexed week, uint256 amount)` — week added, indexed for filtering (I05). **ABI breaking for off-chain consumers**: topic0 hash changes; downstream subgraph / indexers / dashboards / frontends must redeploy the new ABI in the same window as the on-chain upgrade.
- `event WeeklyDistributorPercentSet(uint16 indexed week, uint16[] ids, uint256[] percents)` — **new**, emitted at the end of `setWeeklyDistributorPercent` so weekly percent updates are observable on-chain (I05).

No function signatures, modifiers, or other events were changed.

## Storage layout

Confirmed via `forge inspect contracts/dao/ListaVault.sol:ListaVault storage-layout`:

| Slot | Name | Type |
|---|---|---|
| 4294906062 | `emissionVoting` (existing tail) | `contract IEmissionVoting` |
| **4294906063** | **`distributorBlacklist` (new)** | `mapping(uint16 => bool)` |

All pre-existing variable slots are unchanged. New variable is appended at the end of contract storage — safe for the live transparent proxy upgrade. No `__gap` was used in the original contract; no gap accounting needed. The event-level changes (I04/I05) do not touch storage.

## Access control

| Function | Role | Change |
|---|---|---|
| `batchSetDistributorBlacklist` | `MANAGER` | new — reuses existing role constant `keccak256("MANAGER")` |
| `setWeeklyDistributorPercent` | `OPERATOR` | unchanged (added blacklist precondition inside body) |
| `registerDistributor` | `MANAGER` | unchanged |

No new roles introduced. No changes to `_authorizeUpgrade`, `DEFAULT_ADMIN_ROLE`, `PAUSER`, or `OPERATOR` semantics.

## Risk assessment

| Area | Risk | Note |
|---|---|---|
| Storage collision | 🟢 None | New mapping appended at slot 4294906063; prior layout untouched (verified via `forge inspect`). |
| Fund safety | 🟢 None | Blacklist is an input-side gate only; never moves tokens, never erases past entitlements. Distributors retain access to emissions earned before being blacklisted. |
| Access control | 🟢 None | New write surface is gated by the existing `MANAGER` role. Validation rejects empty arrays and unregistered ids; idempotent on no-ops. |
| External call safety | 🟢 None | No new external calls, no callbacks, no token transfers in the new code path. |
| Voting-path coverage | 🟡 Low | If `EmissionVoting` is active and voters allocate weight to a blacklisted id, that id will still receive emissions for the voted week. By design — voter governance is the source of truth for the voting path. Document for ops if a stronger policy is needed. |
| Off-chain ABI sync | 🟡 Medium | `Deposit` event signature changed (I05). Existing indexers stop receiving `Deposit` until they pick up the new ABI. Coordinate downstream redeploy with the on-chain upgrade window. |

## Deployment

Transparent proxy upgrade on BSC mainnet via the standard TimeLock SOP:

- TimeLock: `0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253`
- ListaVault proxy: `0x307d13267f360f78005f476Fa913F8848F30292A`
- ProxyAdmin (OZ v5, admin of the proxy): `0xd6cd036133cbf6a275b7700ff7b41887a9d5fcae`
- New implementation (already deployed): `0x29202d64986097a099575807ed8284b0fd457167`

TimeLock target = `ProxyAdmin`; calldata = `upgradeAndCall(proxy, newImpl, "")`. Schedule → 1-day delay → execute. No new env vars. No `reinitializer` — new state defaults to zero/false, no migration call. End-to-end flow simulated on an Anvil BSC mainnet fork (schedule → time-skip → execute → impl slot confirmed at the new address).

## Audit

External audit on this branch (PR #108) returned **Informational** overall, 5 findings, all on `ListaVault.sol`:

| ID | Status |
|---|---|
| I01 — `setEmissionVoting` may erase historical voting-based emissions if called with unsettled weeks | Accepted, address via runbook / ops |
| I02 — `setWeeklyDistributorPercent` totalPercent has no lower bound | Accepted, ops policy |
| I03 — `ReentrancyGuardUpgradeable` inherited but not initialized / applied | Accepted, address in a follow-up |
| I04 — unused `Withdraw` event declaration | **Fixed in `ceeede1`** |
| I05 — missing / incomplete events for key state changes | **Fixed in `ceeede1`** |

## Test plan

- [x] `forge build` — no errors
- [x] `forge test --match-path 'test/dao/ListaVault.t.sol'` — 12/12 pass (BSC fork)
- [x] `forge test --match-path 'test/dao/ListaVaultUnit.t.sol'` — 18/18 pass (pure unit, ~2ms)
- [x] `forge test --match-path 'test/EmissionVoting.t.sol'` — 3/3 pass (was failing on master with `free penalty period start`; fix included)
- [x] Storage layout check — new var appended, no slot moves
- [x] Historical-claim preservation verified for both percent and voting paths
- [x] Timelock propose → execute simulated on Anvil BSC fork; proxy impl slot updates to new impl address

🤖 Generated with [Claude Code](https://claude.com/claude-code)
