### PR TITLE
fix: update LISTA token address to correct ETH mainnet address in deploy scripts

### DIFF
--- a/scripts/eth/deploy_listaRevenueDistributor.ts
+++ b/scripts/eth/deploy_listaRevenueDistributor.ts
@@ -15,7 +15,7 @@ async function main() {
   // 2. Fill it into MarketFactory deploy script (listaRevenueDistributor)
   // 3. Call LendingFeeRecipient(0xd10a024602E042dcb9C19e21682c3b896c8B0d30).setMarketFeeRecipient(this proxy address)
   const bot = '0x8d388136d578dCD791D081c6042284CED6d9B0c6'; // Manager Safe
-  const listaAddress = '0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46'; // TODO: replace with LISTA ETH mainnet address once deployed (initialize requires non-zero)
+  const listaAddress = '0x11632069f202b06d5ff56aeb4aabd0662dd1933b'; // LISTA token on ETH mainnet
   const autoBuybackAddress = '0x0000000000000000000000000000000000000000'; // not used on ETH
   const revenueWalletAddress = '0x0000000000000000000000000000000000000000'; // not used on ETH
   const listaDistributeToAddress = '0x0000000000000000000000000000000000000000'; // not used on ETH

--- a/scripts/foundry/eth/deploy_listaRevenueDistributor.sol
+++ b/scripts/foundry/eth/deploy_listaRevenueDistributor.sol
@@ -41,7 +41,7 @@ contract ListaRevenueDistributorDeploy is Script {
     } else {
       // ETH mainnet
       manager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // Manager Safe
-      listaAddress = 0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46; // TODO: replace with real LISTA token address on ETH mainnet
+      listaAddress = 0x11632069f202b06d5ff56aeb4aabd0662dd1933b; // LISTA token on ETH mainnet
     }
 
     vm.startBroadcast(deployerPrivateKey);


### PR DESCRIPTION
## Summary

Update LISTA token address in ETH mainnet deployment scripts from placeholder to the correct mainnet address (`0x11632069f202b06d5ff56aeb4aabd0662dd1933b`).

This was missed in PR #111 merge — the placeholder address `0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46` was left in both Foundry and Hardhat deploy scripts.

## Change Type

- [x] Configuration change (existing contract)
- [ ] Deploy script (new)
- [ ] New contract
- [ ] Test (new)
- [ ] Upgrade (existing proxy)
- [x] Bug fix (audit response)

## Contracts Changed

| Contract | File | Type | Description |
|----------|------|------|-------------|
| Deploy script (Foundry) | `scripts/foundry/eth/deploy_listaRevenueDistributor.sol` | modified | Fix LISTA token address |
| Deploy script (Hardhat) | `scripts/eth/deploy_listaRevenueDistributor.ts` | modified | Fix LISTA token address |

## Key Changes

### LISTA Token Address Fix

| File | Before | After |
|------|--------|-------|
| `scripts/foundry/eth/deploy_listaRevenueDistributor.sol` | `0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46` (placeholder) | `0x11632069f202b06d5ff56aeb4aabd0662dd1933b` (correct ETH mainnet) |
| `scripts/eth/deploy_listaRevenueDistributor.ts` | `0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46` (placeholder) | `0x11632069f202b06d5ff56aeb4aabd0662dd1933b` (correct ETH mainnet) |

## Context

The LISTA token on ETH mainnet address: `0x11632069f202b06d5ff56aeb4aabd0662dd1933b`

This address is required by `ListaRevenueDistributor.initialize()` — the contract stores it as `listaTokenAddress` for whitelist management via `addTokensToWhitelist`.

## Risk Assessment

| Area | Risk | Note |
|------|------|------|
| Deploy correctness | None after fix | Correct LISTA address ensures proper initialization |
| Runtime impact | None | Address only used during `initialize()` call |
| BSC impact | None | BSC deploy scripts are unchanged |

## Deploy Order

Unchanged from PR #111:

```
1. Deploy ListaRevenueDistributor (using corrected LISTA address)
2. Grant EMERGENCY_WITHDRAWER role to Manager Safe (done in deploy script)
3. Record proxy address
4. Fill into moolah MarketFactory deploy script (PR #206)
5. (Multisig) LendingFeeRecipient(0xd10a...e30).setMarketFeeRecipient(new proxy address)
```