### PR TITLE
fix: correct EIP-55 checksum for LISTA token address on ETH mainnet

### DIFF
--- a/scripts/foundry/eth/deploy_listaRevenueDistributor.sol
+++ b/scripts/foundry/eth/deploy_listaRevenueDistributor.sol
@@ -41,7 +41,7 @@ contract ListaRevenueDistributorDeploy is Script {
     } else {
       // ETH mainnet
       manager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // Manager Safe
-      listaAddress = 0x11632069f202b06d5ff56aeb4aabd0662dd1933b; // LISTA token on ETH mainnet
+      listaAddress = 0x11632069F202B06d5FF56AEB4aAbD0662dd1933b; // LISTA token on ETH mainnet
     }
 
     vm.startBroadcast(deployerPrivateKey);


### PR DESCRIPTION
## Summary

Fix an invalid EIP-55 checksum in the Foundry deploy script introduced by PR #113.

PR #113 replaced the placeholder LISTA address with the correct ETH mainnet address but wrote it in all-lowercase form (`0x11632069f202b06d5ff56aeb4aabd0662dd1933b`). Solidity `>=0.8` enforces EIP-55 checksum on address literals at compile time and raises `SyntaxError (9429)`, causing `forge script` to abort at the compilation stage — deployment cannot proceed.

The Hardhat `.ts` script is unaffected (`ethers.js` does not validate checksum).

## Change Type

- [x] Bug fix (compile-time blocker)
- [ ] Configuration change (existing contract)
- [ ] Deploy script (new)
- [ ] New contract
- [ ] Test (new)
- [ ] Upgrade (existing proxy)

## Contracts Changed

| Contract | File | Type | Description |
|----------|------|------|-------------|
| Deploy script (Foundry) | `scripts/foundry/eth/deploy_listaRevenueDistributor.sol` | modified | Fix EIP-55 checksum on LISTA token address |

## Key Changes

| File | Before | After |
|------|--------|-------|
| `scripts/foundry/eth/deploy_listaRevenueDistributor.sol` | `0x11632069f202b06d5ff56aeb4aabd0662dd1933b` (invalid checksum) | `0x11632069F202B06d5FF56AEB4aAbD0662dd1933b` (EIP-55 checksum) |

## Root Cause

The `else` branch (ETH mainnet) in `deploy_listaRevenueDistributor.sol` was never compiled during development — only the Sepolia branch was exercised (its placeholder address happened to be valid checksum). The all-lowercase address slipped through code review because `ethers.js` accepts it silently.

## Verification

```bash
forge build scripts/foundry/eth/deploy_listaRevenueDistributor.sol
# Compiler run successful!
```

## Risk Assessment

| Area | Risk | Note |
|------|------|------|
| Deploy correctness | None | Address value unchanged; only letter casing corrected |
| Runtime impact | None | One-character-class fix, no logic change |
| BSC impact | None | BSC deploy scripts are unchanged |
