### PR TITLE
chore: add Foundry impl-only deploy script for ListaRevenueDistributor

### DIFF
--- a/scripts/foundry/dao/deploy_listaRevenueDistributor_impl.sol
+++ b/scripts/foundry/dao/deploy_listaRevenueDistributor_impl.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.10;
+
+import { Script, console } from "forge-std/Script.sol";
+import { ListaRevenueDistributor } from "../../../contracts/dao/ListaRevenueDistributor.sol";
+
+contract ListaRevenueDistributorImplDeploy is Script {
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy implementation only (no proxy, no upgrade)
+    ListaRevenueDistributor impl = new ListaRevenueDistributor();
+    console.log("ListaRevenueDistributor implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}


### PR DESCRIPTION
## Summary

Add a Foundry deploy script that deploys **only** the `ListaRevenueDistributor` implementation contract (no proxy, no upgrade). This enables the contract to be deployed via the Deploy Automation pipeline, which only supports `forge script`.

## Change Type

- [x] Deploy script (new)

## Contracts Changed

| Contract | File | Type | Description |
|----------|------|------|-------------|
| Deploy script (Foundry) | `scripts/foundry/dao/deploy_listaRevenueDistributor_impl.sol` | new | Impl-only deploy for ListaRevenueDistributor |

## Context

The existing impl deploy script (`scripts/dao/deploy_listaRevenueDistributor_impl.ts`) is Hardhat-based and cannot be used with the Deploy Automation system which requires Foundry scripts.

This script follows the same pattern as other impl-only Foundry scripts in the repo (e.g., `deploy_listaAutoBuyback_impl.sol`, `deploy_listaVault_impl.sol`).

## Usage

```shell
forge script scripts/foundry/dao/deploy_listaRevenueDistributor_impl.sol \
  --rpc-url $BSC_RPC_URL --broadcast --verify --etherscan-api-key $BSCSCAN_API_KEY
```

## Risk Assessment

| Area | Risk | Note |
|------|------|------|
| Runtime impact | None | Script deploys impl only, no proxy interaction |
| Existing scripts | None | Does not modify any existing files |