### PR TITLE
feat(dao): add MANAGER changeUserTranche correction (pre-finalize)

### DIFF
--- a/contracts/dao/PreIPODistributor.sol
+++ b/contracts/dao/PreIPODistributor.sol
@@ -110,6 +110,8 @@ contract PreIPODistributor is
 
     event SetPaused(uint64 indexed saleId, bool paused);
 
+    event ChangeUserTranche(uint64 indexed saleId, address indexed account, uint8 oldTranche, uint8 newTranche);
+
     event DepositWhitelist(
         uint64 indexed saleId,
         address indexed account,
@@ -259,6 +261,26 @@ contract PreIPODistributor is
         require(sale.whitelistRoot != bytes32(0), "Invalid saleId");
         sale.paused = _paused;
         emit SetPaused(_saleId, _paused);
+    }
+
+    /// @dev MANAGER correction of an account's locked tranche. Allowed until the settlement root
+    ///      is finalized; a pending (not-yet-finalized) root does not block it, but the pending
+    ///      root must then be revoked and rebuilt off-chain to reflect the change. Deposit amounts
+    ///      are untouched; the tranche never affects on-chain accounting.
+    function changeUserTranche(uint64 _saleId, address _account, uint8 _tranche)
+        external
+        onlyRole(MANAGER)
+    {
+        Sale storage sale = sales[_saleId];
+        require(sale.whitelistRoot != bytes32(0), "Invalid saleId");
+        require(settlements[_saleId].root == bytes32(0), "Settlement finalized");
+        require(_tranche == TRANCHE_UNLOCKED || _tranche == TRANCHE_LOCKED, "Invalid tranche");
+        uint8 oldTranche = userTranche[_saleId][_account];
+        require(oldTranche != 0, "Tranche not set");
+        require(_tranche != oldTranche, "Same tranche");
+
+        userTranche[_saleId][_account] = _tranche;
+        emit ChangeUserTranche(_saleId, _account, oldTranche, _tranche);
     }
 
     /// @dev Whitelist-round deposit. First deposit needs a valid proof; top-ups skip it.

--- a/test/dao/PreIPODistributor.t.sol
+++ b/test/dao/PreIPODistributor.t.sol
@@ -424,6 +424,80 @@ contract PreIPODistributorTest is Test {
         assertEq(distributor.userTranche(saleId, alice), PKLSH);
     }
 
+    // ---- changeUserTranche (manager correction) ----
+
+    function test_changeUserTranche_ok() public {
+        uint64 saleId = _saleWithDeposit(); // alice deposited XKLSH
+        assertEq(distributor.userTranche(saleId, alice), XKLSH);
+
+        vm.expectEmit(true, true, false, true, address(distributor));
+        emit PreIPODistributor.ChangeUserTranche(saleId, alice, XKLSH, PKLSH);
+        vm.prank(manager);
+        distributor.changeUserTranche(saleId, alice, PKLSH);
+
+        assertEq(distributor.userTranche(saleId, alice), PKLSH);
+        // deposit amounts are untouched
+        assertEq(distributor.deposits(saleId, alice), 200e18);
+    }
+
+    function test_changeUserTranche_acl() public {
+        uint64 saleId = _saleWithDeposit();
+        vm.prank(outsider);
+        vm.expectRevert();
+        distributor.changeUserTranche(saleId, alice, PKLSH);
+    }
+
+    function test_changeUserTranche_invalidSale_reverts() public {
+        vm.prank(manager);
+        vm.expectRevert("Invalid saleId");
+        distributor.changeUserTranche(0, alice, PKLSH);
+    }
+
+    function test_changeUserTranche_invalidTranche_reverts() public {
+        uint64 saleId = _saleWithDeposit();
+        vm.prank(manager);
+        vm.expectRevert("Invalid tranche");
+        distributor.changeUserTranche(saleId, alice, 3);
+    }
+
+    function test_changeUserTranche_noDeposit_reverts() public {
+        uint64 saleId = _saleWithDeposit(); // only alice deposited
+        vm.prank(manager);
+        vm.expectRevert("Tranche not set");
+        distributor.changeUserTranche(saleId, carol, PKLSH);
+    }
+
+    function test_changeUserTranche_sameTranche_reverts() public {
+        uint64 saleId = _saleWithDeposit(); // alice is XKLSH
+        vm.prank(manager);
+        vm.expectRevert("Same tranche");
+        distributor.changeUserTranche(saleId, alice, XKLSH);
+    }
+
+    function test_changeUserTranche_whileSettlementPending_ok() public {
+        uint64 saleId = _saleWithDeposit();
+        vm.prank(bot);
+        distributor.setSettlementRoot(saleId, keccak256("settle"), 50e18);
+
+        // a pending (not finalized) root does not block the correction
+        vm.prank(manager);
+        distributor.changeUserTranche(saleId, alice, PKLSH);
+        assertEq(distributor.userTranche(saleId, alice), PKLSH);
+    }
+
+    function test_changeUserTranche_afterFinalize_reverts() public {
+        uint64 saleId = _saleWithDeposit();
+        vm.prank(bot);
+        distributor.setSettlementRoot(saleId, keccak256("settle"), 50e18);
+        vm.warp(block.timestamp + 6 hours);
+        vm.prank(bot);
+        distributor.finalizeSettlement(saleId);
+
+        vm.prank(manager);
+        vm.expectRevert("Settlement finalized");
+        distributor.changeUserTranche(saleId, alice, PKLSH);
+    }
+
     // ---- settlement: set / finalize ----
 
     // create a sale, deposit in WL round, return saleId (totalDeposits = 200e18)


### PR DESCRIPTION
## Summary

Adds a MANAGER-only correction method, `changeUserTranche`, to `PreIPODistributor`. It lets operations fix an account's locked delivery tranche after deposit (the tranche is otherwise locked at an account's first deposit), up until the settlement root is finalized. Stacks on the merged audit-fix work (#120); a single commit on top of `master`.

## What it does

```solidity
function changeUserTranche(uint64 _saleId, address _account, uint8 _tranche) external onlyRole(MANAGER)
```

- Overrides `userTranche[saleId][account]` and emits `ChangeUserTranche(saleId, account, oldTranche, newTranche)`.
- **Does not touch deposit amounts** (`deposits` / `pubDeposits`) or the sale aggregates — the tranche never affects on-chain accounting, only off-chain delivery routing.

## Guards

- `onlyRole(MANAGER)`.
- Valid sale (`whitelistRoot != 0`).
- **`settlements[saleId].root == 0`** — allowed until the root is *finalized*. A pending (not-yet-finalized) root does **not** block the change; the operator must then revoke the pending root and rebuild the settlement tree off-chain so it reflects the corrected tranche.
- New tranche must be valid (`TRANCHE_UNLOCKED` / `TRANCHE_LOCKED`).
- Account must already have a tranche (`oldTranche != 0`, i.e. has deposited).
- New tranche must differ from the current one (`"Same tranche"`).

## Storage / upgrade safety

Adds **no storage** (one external function + one event). The storage layout is byte-identical to the current production contract, and remains an **append-only, upgrade-safe** superset of the live #118 subscription impl (`sales`…`nextSaleId` at slots 301–305 unchanged; `settlements` / `claimed` / `waitingPeriod` at 306–308). The same `upgradeToAndCall(newImpl, initializeV2())` upgrade carries this change.

## Testing

`forge test --match-contract PreIPODistributorTest` — **64 passing**, including 8 new cases:

- `ok` — manager flips XKLSH → PKLSH; deposits untouched, event emitted
- `acl` — non-MANAGER reverts
- `invalidSale` / `invalidTranche` / `noDeposit` / `sameTranche` reverts
- `whileSettlementPending_ok` — allowed while a root is pending
- `afterFinalize_reverts` — reverts once finalized (`"Settlement finalized"`)

## Operational note

Because a correction is permitted while a root is pending, `finalizeSettlement` does not detect a tranche changed underneath a pending root — operations must revoke-and-rebuild before finalizing. Same class of operational discipline as L03.