### PR TITLE
chore(dao): add PreIPODistributor impl-only deploy script for BSC

### DIFF
--- a/scripts/foundry/dao/deploy_PreIPO_impl.sol
+++ b/scripts/foundry/dao/deploy_PreIPO_impl.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.8.10;
+
+import { Script, console } from "forge-std/Script.sol";
+import { PreIPODistributor } from "../../../contracts/dao/PreIPODistributor.sol";
+
+/**
+ * Deploy a new PreIPODistributor implementation on BSC (impl only — no proxy, no upgrade call).
+ *
+ * Usage:
+ *   forge script scripts/foundry/dao/deploy_PreIPO_impl.sol:PreIPODistributorImplDeploy \
+ *     --rpc-url bsc --broadcast --verify -vvvv
+ *
+ * Requires env: DEPLOYER_BSC_PRIVATE_KEY / DEPLOYER_TESTNET_PRIVATE_KEY, BSCSCAN_API_KEY (--verify).
+ */
+contract PreIPODistributorImplDeploy is Script {
+    uint256 constant BSC_MAINNET = 56;
+    uint256 constant BSC_TESTNET = 97;
+
+    function run() public {
+        uint256 pk = _deployerKey();
+        address deployer = vm.addr(pk);
+        console.log("Chain id:", block.chainid);
+        console.log("Deployer:", deployer);
+
+        vm.startBroadcast(pk);
+        PreIPODistributor impl = new PreIPODistributor();
+        vm.stopBroadcast();
+
+        console.log("PreIPODistributor implementation:", address(impl));
+        console.log("--- upgrade calldata for the admin multisig (target = the proxy) ---");
+        console.log("[first settlement upgrade] upgradeToAndCall(impl, initializeV2()):");
+        console.logBytes(
+            abi.encodeWithSignature(
+                "upgradeToAndCall(address,bytes)",
+                address(impl),
+                abi.encodeCall(PreIPODistributor.initializeV2, ())
+            )
+        );
+        console.log("[subsequent impl swap] upgradeTo(impl):");
+        console.logBytes(abi.encodeWithSignature("upgradeTo(address)", address(impl)));
+    }
+
+    function _deployerKey() internal view returns (uint256) {
+        if (block.chainid == BSC_MAINNET) {
+            return vm.envUint("DEPLOYER_BSC_PRIVATE_KEY");
+        } else if (block.chainid == BSC_TESTNET) {
+            return vm.envUint("DEPLOYER_TESTNET_PRIVATE_KEY");
+        } else {
+            revert("Unsupported chain (expected BSC 56 or BSC testnet 97)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an impl-only Foundry deploy script for `PreIPODistributor` on BSC: `scripts/foundry/dao/deploy_PreIPO_impl.sol`.

Deploys a new implementation (no proxy, no upgrade call) for the admin multisig (`DEFAULT_ADMIN_ROLE`) to wire into the live proxy.

## Details

- Chain-aware deployer key: `DEPLOYER_BSC_PRIVATE_KEY` (mainnet 56) / `DEPLOYER_TESTNET_PRIVATE_KEY` (testnet 97).
- Deploys `new PreIPODistributor()`, logs the impl address, and prints ready-to-use upgrade calldata for the multisig to run on the proxy:
  - **first settlement upgrade** → `upgradeToAndCall(impl, initializeV2())` (runs `initializeV2`, setting `waitingPeriod = 6h`)
  - **subsequent impl swaps** → `upgradeTo(impl)`

## Usage

```
forge script scripts/foundry/dao/deploy_PreIPO_impl.sol:PreIPODistributorImplDeploy --rpc-url bsc --broadcast --verify -vvvv
```

Requires env: `DEPLOYER_BSC_PRIVATE_KEY` / `DEPLOYER_TESTNET_PRIVATE_KEY`, `BSCSCAN_API_KEY` (for `--verify`).
